### PR TITLE
build: dont poison cargo cache & keep our own dl cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +754,7 @@ dependencies = [
  "clap",
  "dirs",
  "futures-util",
+ "hex",
  "kinode_process_lib",
  "nix",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ base64 = "0.21"
 clap = { version = "4.4", features = ["cargo", "string"] }
 dirs = "5.0"
 futures-util = "0.3"
+hex = "0.4"
 kinode_process_lib = { git = "https://github.com/uqbar-dao/process_lib.git", tag = "v0.5.5-alpha" }
 nix = { version = "0.27", features = ["process", "signal", "term"] }
 regex = "1.0"


### PR DESCRIPTION
@dr-frmr dang looks like we clobbered work. My preference is to keep this PR over #62 because this includes an additional speed boost: keeping and using a cache for downloaded files that improves build speeds slightly (esp since the `wasi...` file is p big).