### PR TITLE
change default to debug, with `--release` flag

### DIFF
--- a/src/build_start_package/mod.rs
+++ b/src/build_start_package/mod.rs
@@ -10,8 +10,9 @@ pub async fn execute(
     verbose: bool,
     url: &str,
     skip_deps_check: bool,
+    release: bool,
 ) -> anyhow::Result<()> {
-    build::execute(package_dir, no_ui, ui_only, verbose, skip_deps_check).await?;
+    build::execute(package_dir, no_ui, ui_only, verbose, skip_deps_check, release).await?;
     start_package::execute(package_dir, url).await?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,8 +79,16 @@ async fn execute(
             let ui_only = build_matches.get_one::<bool>("UI_ONLY").unwrap();
             let verbose = !build_matches.get_one::<bool>("QUIET").unwrap();
             let skip_deps_check = build_matches.get_one::<bool>("SKIP_DEPS_CHECK").unwrap();
+            let release = build_matches.get_one::<bool>("RELEASE").unwrap();
 
-            build::execute(&package_dir, *no_ui, *ui_only, verbose, *skip_deps_check).await
+            build::execute(
+                &package_dir,
+                *no_ui,
+                *ui_only,
+                verbose,
+                *skip_deps_check,
+                *release,
+            ).await
         },
         Some(("build-start-package", build_start_matches)) => {
 
@@ -96,6 +104,7 @@ async fn execute(
                 },
             };
             let skip_deps_check = build_start_matches.get_one::<bool>("SKIP_DEPS_CHECK").unwrap();
+            let release = build_start_matches.get_one::<bool>("RELEASE").unwrap();
 
             build_start_package::execute(
                 &package_dir,
@@ -104,6 +113,7 @@ async fn execute(
                 verbose,
                 &url,
                 *skip_deps_check,
+                *release,
             ).await
         },
         Some(("dev-ui", dev_ui_matches)) => {
@@ -359,6 +369,12 @@ async fn make_app(current_dir: &std::ffi::OsString) -> anyhow::Result<Command> {
                 .help("If set, do not check for dependencies")
                 .required(false)
             )
+            .arg(Arg::new("RELEASE")
+                .action(ArgAction::SetTrue)
+                .long("release")
+                .help("If set, compile release build (default: debug build)")
+                .required(false)
+            )
         )
         .subcommand(Command::new("build-start-package")
             .about("Build and start a Kinode package")
@@ -407,6 +423,12 @@ async fn make_app(current_dir: &std::ffi::OsString) -> anyhow::Result<Command> {
                 .short('s')
                 .long("skip-deps-check")
                 .help("If set, do not check for dependencies")
+                .required(false)
+            )
+            .arg(Arg::new("RELEASE")
+                .action(ArgAction::SetTrue)
+                .long("release")
+                .help("If set, compile release build (default: debug build)")
                 .required(false)
             )
         )

--- a/src/run_tests/mod.rs
+++ b/src/run_tests/mod.rs
@@ -291,10 +291,17 @@ async fn run_tests(
 
 async fn handle_test(detached: bool, runtime_path: &Path, test: Test) -> anyhow::Result<()> {
     for setup_package_path in &test.setup_package_paths {
-        build::execute(&setup_package_path, false, false, test.package_build_verbose, false).await?;
+        build::execute(
+            &setup_package_path,
+            false,
+            false,
+            test.package_build_verbose,
+            false,
+            false,
+        ).await?;
     }
     for TestPackage { ref path, .. } in &test.test_packages {
-        build::execute(path, false, false, test.package_build_verbose, false).await?;
+        build::execute(path, false, false, test.package_build_verbose, false, false).await?;
     }
 
     // Initialize variables for master node and nodes list


### PR DESCRIPTION
## Problem

Resolves #65

## Solution

* `kit build` now accepts `--release` flag
* `kit boot-fake-node` now accepts `--release` flag (TODO)
* Kinode Core `build.rs` now reads in `--release` and passes that to `kit::build::execute` (TODO)

## Docs Update

TODO
[Corresponding docs PR](https://github.com/kinode-dao/kinode-book/pull/my-pr-number)

## Notes

None.