### PR TITLE
boot-fake-node: build runtime debug by default or `--release`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,7 @@ async fn execute(
             let fake_node_name = boot_matches.get_one::<String>("NODE_NAME").unwrap();
             let password = boot_matches.get_one::<String>("PASSWORD").unwrap();
             let is_persist = boot_matches.get_one::<bool>("PERSIST").unwrap();
+            let release = boot_matches.get_one::<bool>("RELEASE").unwrap();
 
             boot_fake_node::execute(
                 runtime_path,
@@ -70,6 +71,7 @@ async fn execute(
                 fake_node_name,
                 password,
                 *is_persist,
+                *release,
                 vec![],
             ).await
         },
@@ -318,6 +320,12 @@ async fn make_app(current_dir: &std::ffi::OsString) -> anyhow::Result<Command> {
                 .long("password")
                 .help("Password to login")
                 .default_value("secret")
+            )
+            .arg(Arg::new("RELEASE")
+                .action(ArgAction::SetTrue)
+                .long("release")
+                .help("If set and given --runtime-path, compile release build [default: debug build]")
+                .required(false)
             )
             .arg(Arg::new("help")
                 .long("help")

--- a/src/run_tests/mod.rs
+++ b/src/run_tests/mod.rs
@@ -442,6 +442,7 @@ pub async fn execute(config_path: &str) -> anyhow::Result<()> {
                 compile_runtime(
                     &runtime_path,
                     config.runtime_build_verbose,
+                    config.runtime_build_release,
                 )?;
                 runtime_path.join("target/release/kinode")
             } else {

--- a/src/run_tests/types.rs
+++ b/src/run_tests/types.rs
@@ -11,6 +11,7 @@ use serde::{Serialize, Deserialize};
 pub struct Config {
     pub runtime: Runtime,
     pub runtime_build_verbose: bool,
+    pub runtime_build_release: bool,
     pub tests: Vec<Test>,
 }
 


### PR DESCRIPTION
## Problem

Resolves #65

## Solution

`kit boot-fake-node` now accepts `--release` flag

## Docs Update

[Corresponding docs PR](https://github.com/kinode-dao/kinode-book/pull/134)

## Notes

None.