### PR TITLE
add no-ui file-transfer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -603,7 +603,7 @@ async fn make_app(current_dir: &std::ffi::OsString) -> anyhow::Result<Command> {
                 .short('t')
                 .long("template")
                 .help("Template to create")
-                .value_parser(["chat", "echo", "fibonacci"])
+                .value_parser(["chat", "echo", "fibonacci", "file_transfer"])
                 .default_value("chat")
             )
             .arg(Arg::new("UI")

--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -16,6 +16,7 @@ pub enum Template {
     Chat,
     Echo,
     Fibonacci,
+    FileTransfer,
 }
 
 impl Language {
@@ -34,6 +35,7 @@ impl Template {
             Template::Chat => "chat",
             Template::Echo => "echo",
             Template::Fibonacci => "fibonacci",
+            Template::FileTransfer => "file_transfer",
         }.to_string()
     }
 }
@@ -55,6 +57,7 @@ impl From<&String> for Template {
             "chat" => Template::Chat,
             "echo" => Template::Echo,
             "fibonacci" => Template::Fibonacci,
+            "file_transfer" => Template::FileTransfer,
             _ => panic!("kit: template must be 'chat', 'echo', or 'fibonacci'; not '{s}'"),
         }
     }

--- a/src/new/templates/rust/no-ui/file_transfer/.gitignore
+++ b/src/new/templates/rust/no-ui/file_transfer/.gitignore
@@ -1,0 +1,12 @@
+target
+*/target/
+pkg/*.wasm
+pkg/ui
+*.swp
+*.swo
+*/wasi_snapshot_preview1.wasm
+*/wit/
+*/process_env
+ui/dist
+ui/node_modules
+node_modules

--- a/src/new/templates/rust/no-ui/file_transfer/pkg/manifest.json
+++ b/src/new/templates/rust/no-ui/file_transfer/pkg/manifest.json
@@ -1,0 +1,15 @@
+[
+    {
+        "process_name": "{package_name}",
+        "process_wasm_path": "/{package_name}.wasm",
+        "on_exit": "Restart",
+        "request_networking": true,
+        "request_capabilities": [
+            "http_server:distro:sys",
+            "net:distro:sys",
+            "vfs:distro:sys"
+        ],
+        "grant_capabilities": [],
+        "public": true
+    }
+]

--- a/src/new/templates/rust/no-ui/file_transfer/pkg/metadata.json
+++ b/src/new/templates/rust/no-ui/file_transfer/pkg/metadata.json
@@ -1,0 +1,5 @@
+{
+    "package": "{package_name}",
+    "publisher": "{publisher}",
+    "version": [0, 1, 0]
+}

--- a/src/new/templates/rust/no-ui/file_transfer/worker/Cargo.toml_
+++ b/src/new/templates/rust/no-ui/file_transfer/worker/Cargo.toml_
@@ -1,0 +1,23 @@
+[package]
+name = "worker"
+version = "0.1.0"
+edition = "2021"
+
+[profile.release]
+panic = "abort"
+opt-level = "s"
+lto = true
+
+[dependencies]
+anyhow = "1.0"
+bincode = "1.3.3"
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib.git", tag = "v0.5.9-alpha" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "efcc759" }
+
+[lib]
+crate-type = ["cdylib"]
+
+[package.metadata.component]
+package = "kinode:process"

--- a/src/new/templates/rust/no-ui/file_transfer/worker/src/lib.rs
+++ b/src/new/templates/rust/no-ui/file_transfer/worker/src/lib.rs
@@ -1,0 +1,199 @@
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+use kinode_process_lib::{
+    await_message, call_init, get_blob, println,
+    vfs::{open_dir, open_file, Directory, File, SeekFrom},
+    Address, Message, ProcessId, Request, Response,
+};
+
+wit_bindgen::generate!({
+    path: "wit",
+    world: "process",
+    exports: {
+        world: Component,
+    },
+});
+
+const CHUNK_SIZE: u64 = 1048576; // 1MB
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum WorkerRequest {
+    Initialize {
+        name: String,
+        target_worker: Option<Address>,
+    },
+    Chunk {
+        name: String,
+        offset: u64,
+        length: u64,
+    },
+    Size(u64),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum TransferRequest {
+    Progress { name: String, progress: u64 },
+}
+
+fn handle_message(
+    our: &Address,
+    file: &mut Option<File>,
+    files_dir: &Directory,
+    size: &mut Option<u64>,
+) -> anyhow::Result<bool> {
+    let message = await_message()?;
+
+    match message {
+        Message::Request {
+            ref body,
+            ..
+        } => {
+            let request = serde_json::from_slice::<WorkerRequest>(body)?;
+
+            match request {
+                WorkerRequest::Initialize {
+                    name,
+                    target_worker,
+                } => {
+                    // initialize command from main process,
+                    // sets up worker, matches on if it's a sender or receiver.
+                    // target_worker = None, we are receiver, else sender.
+
+                    // open/create empty file in both cases.
+                    let mut active_file =
+                        open_file(&format!("{}/{}", files_dir.path, &name), true)?;
+
+                    match target_worker {
+                        Some(target_worker) => {
+                            // we have a target, chunk the data, and send it.
+                            let size = active_file.metadata()?.len;
+                            let num_chunks = (size as f64 / CHUNK_SIZE as f64).ceil() as u64;
+
+                            // give the receiving worker a size request so it can track it's progress!
+                            Request::new()
+                                .body(serde_json::to_vec(&WorkerRequest::Size(size))?)
+                                .target(target_worker.clone())
+                                .send()?;
+
+                            active_file.seek(SeekFrom::Start(0))?;
+
+                            for i in 0..num_chunks {
+                                let offset = i * CHUNK_SIZE;
+                                let length = CHUNK_SIZE.min(size - offset);
+
+                                let mut buffer = vec![0; length as usize];
+                                active_file.read_at(&mut buffer)?;
+
+                                Request::new()
+                                    .body(serde_json::to_vec(&WorkerRequest::Chunk {
+                                        name: name.clone(),
+                                        offset,
+                                        length,
+                                    })?)
+                                    .target(target_worker.clone())
+                                    .blob_bytes(buffer)
+                                    .send()?;
+                            }
+                            Response::new().body(serde_json::to_vec(&"Done")?).send()?;
+                            return Ok(true);
+                        }
+                        None => {
+                            // waiting for response, store created empty file.
+                            *file = Some(active_file);
+                            Response::new()
+                                .body(serde_json::to_vec(&"Started")?)
+                                .send()?;
+                        }
+                    }
+                }
+                // someone sending a chunk to us!
+                WorkerRequest::Chunk {
+                    name,
+                    offset,
+                    length,
+                } => {
+                    let file = match file {
+                        Some(file) => file,
+                        None => {
+                            return Err(anyhow::anyhow!(
+                                "{package_name} worker: receive error: no file initialized"
+                            ));
+                        }
+                    };
+
+                    let bytes = match get_blob() {
+                        Some(blob) => blob.bytes,
+                        None => {
+                            return Err(anyhow::anyhow!("{package_name} worker: receive error: no blob"));
+                        }
+                    };
+
+                    // file.seek(SeekFrom::Start(offset))?; seek not necessary if the sends come in order.
+                    file.write_all(&bytes)?;
+                    // if sender has sent us a size, give a progress update to main transfer!
+                    if let Some(size) = size {
+                        let progress = ((offset + length) as f64 / *size as f64 * 100.0) as u64;
+
+                        // send update to main process
+                        let main_app = Address {
+                            node: our.node.clone(),
+                            process: ProcessId::from_str(
+                                "{package_name}:{package_name}:{publisher}",
+                            )?,
+                        };
+
+                        Request::new()
+                            .body(serde_json::to_vec(&TransferRequest::Progress {
+                                name,
+                                progress,
+                            })?)
+                            .target(&main_app)
+                            .send()?;
+
+                        if progress >= 100 {
+                            return Ok(true);
+                        }
+                    }
+                }
+                WorkerRequest::Size(incoming_size) => {
+                    *size = Some(incoming_size);
+                }
+            }
+        }
+        _ => {
+            println!("{package_name} worker: got something else than request...");
+        }
+    }
+    Ok(false)
+}
+
+call_init!(init);
+
+fn init(our: Address) {
+    println!("{package_name} worker: begin");
+    let start = std::time::Instant::now();
+
+    let drive_path = format!("{}/files", our.package_id());
+    let files_dir = open_dir(&drive_path, false).unwrap();
+
+    let mut file: Option<File> = None;
+    let mut size: Option<u64> = None;
+
+    loop {
+        match handle_message(&our, &mut file, &files_dir, &mut size) {
+            Ok(exit) => {
+                if exit {
+                    println!(
+                        "{package_name} worker done: exiting, took {:?}",
+                        start.elapsed()
+                    );
+                    break;
+                }
+            }
+            Err(e) => {
+                println!("{package_name}: worker error: {:?}", e);
+            }
+        };
+    }
+}

--- a/src/new/templates/rust/no-ui/file_transfer/{package_name}/Cargo.toml_
+++ b/src/new/templates/rust/no-ui/file_transfer/{package_name}/Cargo.toml_
@@ -1,0 +1,24 @@
+[package]
+name = "{package_name}"
+version = "0.1.0"
+edition = "2021"
+
+[profile.release]
+panic = "abort"
+opt-level = "s"
+lto = true
+
+[dependencies]
+anyhow = "1.0"
+bincode = "1.3.3"
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib.git", tag = "v0.5.9-alpha" }
+multipart = "0.18.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "efcc759" }
+
+[lib]
+crate-type = ["cdylib"]
+
+[package.metadata.component]
+package = "kinode:process"

--- a/src/new/templates/rust/no-ui/file_transfer/{package_name}/src/lib.rs
+++ b/src/new/templates/rust/no-ui/file_transfer/{package_name}/src/lib.rs
@@ -1,0 +1,186 @@
+use kinode_process_lib::{
+    await_message, call_init, our_capabilities, println, spawn,
+    vfs::{create_drive, metadata, open_dir, Directory, FileType},
+    Address, Message, OnExit, Request, Response,
+};
+use serde::{Deserialize, Serialize};
+
+wit_bindgen::generate!({
+    path: "wit",
+    world: "process",
+    exports: {
+        world: Component,
+    },
+});
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum TransferRequest {
+    ListFiles,
+    Download { name: String, target: Address },
+    Progress { name: String, progress: u64 },
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum TransferResponse {
+    ListFiles(Vec<FileInfo>),
+    Download { name: String, worker: Address },
+    Done,
+    Started,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct FileInfo {
+    pub name: String,
+    pub size: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum WorkerRequest {
+    Initialize {
+        name: String,
+        target_worker: Option<Address>,
+    },
+}
+
+fn ls_files(files_dir: &Directory) -> anyhow::Result<Vec<FileInfo>> {
+    let entries = files_dir.read()?;
+    let files: Vec<FileInfo> = entries
+        .iter()
+        .filter_map(|file| match file.file_type {
+            FileType::File => match metadata(&file.path) {
+                Ok(metadata) => Some(FileInfo {
+                    name: file.path.clone(),
+                    size: metadata.len,
+                }),
+                Err(_) => None,
+            },
+            _ => None,
+        })
+        .collect();
+
+    Ok(files)
+}
+
+fn handle_transfer_request(
+    our: &Address,
+    source: &Address,
+    body: &Vec<u8>,
+    files_dir: &Directory,
+) -> anyhow::Result<()> {
+    let transfer_request = serde_json::from_slice::<TransferRequest>(body)?;
+
+    match transfer_request {
+        TransferRequest::ListFiles => {
+            let files = ls_files(files_dir)?;
+
+            Response::new()
+                .body(serde_json::to_vec(&TransferResponse::ListFiles(files))?)
+                .send()?;
+        }
+        TransferRequest::Download { name, target } => {
+            // spin up a worker, initialize based on whether it's a downloader or a sender.
+            let our_worker = spawn(
+                None,
+                &format!("{}/pkg/worker.wasm", our.package_id()),
+                OnExit::None,
+                our_capabilities(),
+                vec![],
+                false,
+            )?;
+
+            let our_worker_address = Address {
+                node: our.node.clone(),
+                process: our_worker,
+            };
+
+            match source.node == our.node {
+                true => {
+                    // we want to download a file
+                    let _resp = Request::new()
+                        .body(serde_json::to_vec(&WorkerRequest::Initialize {
+                            name: name.clone(),
+                            target_worker: None,
+                        })?)
+                        .target(&our_worker_address)
+                        .send_and_await_response(5)??;
+
+                    // send our initialized worker address to the other node
+                    Request::new()
+                        .body(serde_json::to_vec(&TransferRequest::Download {
+                            name: name.clone(),
+                            target: our_worker_address,
+                        })?)
+                        .target(&target)
+                        .send()?;
+                }
+                false => {
+                    // they want to download a file
+                    Request::new()
+                        .body(serde_json::to_vec(&WorkerRequest::Initialize {
+                            name: name.clone(),
+                            target_worker: Some(target),
+                        })?)
+                        .target(&our_worker_address)
+                        .send()?;
+                }
+            }
+        }
+        TransferRequest::Progress { name, progress } => {
+            println!("file: {} progress: {}%", name, progress);
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_transfer_response(
+    source: &Address,
+    body: &Vec<u8>,
+    _is_http: bool,
+) -> anyhow::Result<()> {
+    let transfer_response = serde_json::from_slice::<TransferResponse>(body)?;
+
+    match transfer_response {
+        TransferResponse::ListFiles(files) => {
+            println!("got files from node: {:?} ,files: {:?}", source, files);
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
+
+fn handle_message(our: &Address, files_dir: &Directory) -> anyhow::Result<()> {
+    let message = await_message()?;
+
+    match message {
+        Message::Response {
+            ref source,
+            ref body,
+            ..
+        } => handle_transfer_response(source, body, false),
+        Message::Request {
+            ref source,
+            ref body,
+            ..
+        } => handle_transfer_request(&our, source, body, files_dir),
+    }
+}
+
+call_init!(init);
+
+fn init(our: Address) {
+    println!("{package_name}: begin");
+
+    let drive_path = create_drive(our.package_id(), "files").unwrap();
+    let files_dir = open_dir(&drive_path, false).unwrap();
+
+    loop {
+        match handle_message(&our, &files_dir) {
+            Ok(()) => {}
+            Err(e) => {
+                println!("{package_name}: error: {:?}", e);
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Problem

We need more templates. #69

## Solution

Add file_transfer.

## Docs Update

[Corresponding docs PR](https://github.com/kinode-dao/kinode-book/pull/136)

## Notes

~~Not currently working as of 54b1f25. See https://gist.github.com/hosted-fornet/9a604116ea70adae32cab20509cb0bbb~~

Testing looks like

```
# Start fake.os
kit f

# Start fake2.os (different terminal)
kit f -h /tmp/kinode-fake-node-2 -p 8081 -f fake2.os

# Start file_transfer on each
kit n file_transfer -t file_transfer
kit b file_transfer
kit s file_transfer
kit s file_transfer -p 8081

# On fake.os, try to `ListFiles`
m fake2.os@foo:foo:template.os "ListFiles"
```

EDIT: It is working if you use the proper `m` flags, see comments below.