### PR TITLE
`new` bugfixes

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -2,7 +2,6 @@ use std::fs::File;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
-use reqwest;
 use serde::{Serialize, Deserialize};
 use tokio::fs;
 use tracing::{info, instrument};

--- a/src/inject_message/mod.rs
+++ b/src/inject_message/mod.rs
@@ -3,7 +3,6 @@ use std::io::Read;
 
 #[allow(deprecated)]
 use base64::{decode, encode};
-use reqwest;
 use serde_json::{Value, json};
 use tracing::{info, instrument};
 

--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -163,6 +163,17 @@ pub fn execute(
                 })
         })
         .collect();
+
+    if path_to_content.is_empty() {
+        return Err(anyhow::anyhow!(
+            "The {}/{}/{} language/template/ui combination isn't available. See {} for available language/template/ui combinations.",
+            language.to_string(),
+            template.to_string(),
+            if ui { "'yes ui'" } else { "'no ui'" },
+            "https://book.kinode.org/kit/new.html#existshas-ui-enabled-vesion",
+        ));
+    }
+
     if ui && path_to_content.keys().filter(|p| !p.starts_with("ui")).count() == 0 {
         // Only `ui/` exists
         return Err(anyhow::anyhow!(

--- a/src/new/templates/javascript/no-ui/chat/pkg/manifest.json
+++ b/src/new/templates/javascript/no-ui/chat/pkg/manifest.json
@@ -5,8 +5,7 @@
         "on_exit": "Restart",
         "request_networking": true,
         "request_capabilities": [
-            "http_server:distro:sys",
-            "net:distro:sys"
+            "http_server:distro:sys"
         ],
         "grant_capabilities": [],
         "public": true

--- a/src/new/templates/javascript/no-ui/echo/pkg/manifest.json
+++ b/src/new/templates/javascript/no-ui/echo/pkg/manifest.json
@@ -5,8 +5,7 @@
         "on_exit": "Restart",
         "request_networking": true,
         "request_capabilities": [
-            "http_server:distro:sys",
-            "net:distro:sys"
+            "http_server:distro:sys"
         ],
         "grant_capabilities": [],
         "public": true

--- a/src/new/templates/javascript/no-ui/fibonacci/pkg/manifest.json
+++ b/src/new/templates/javascript/no-ui/fibonacci/pkg/manifest.json
@@ -5,8 +5,7 @@
         "on_exit": "Restart",
         "request_networking": true,
         "request_capabilities": [
-            "http_server:distro:sys",
-            "net:distro:sys"
+            "http_server:distro:sys"
         ],
         "grant_capabilities": [],
         "public": true

--- a/src/new/templates/python/no-ui/chat/pkg/manifest.json
+++ b/src/new/templates/python/no-ui/chat/pkg/manifest.json
@@ -5,8 +5,7 @@
         "on_exit": "Restart",
         "request_networking": true,
         "request_capabilities": [
-            "http_server:distro:sys",
-            "net:distro:sys"
+            "http_server:distro:sys"
         ],
         "grant_capabilities": [],
         "public": true

--- a/src/new/templates/python/no-ui/echo/pkg/manifest.json
+++ b/src/new/templates/python/no-ui/echo/pkg/manifest.json
@@ -5,8 +5,7 @@
         "on_exit": "Restart",
         "request_networking": true,
         "request_capabilities": [
-            "http_server:distro:sys",
-            "net:distro:sys"
+            "http_server:distro:sys"
         ],
         "grant_capabilities": [],
         "public": true

--- a/src/new/templates/python/no-ui/fibonacci/pkg/manifest.json
+++ b/src/new/templates/python/no-ui/fibonacci/pkg/manifest.json
@@ -5,8 +5,7 @@
         "on_exit": "Restart",
         "request_networking": true,
         "request_capabilities": [
-            "http_server:distro:sys",
-            "net:distro:sys"
+            "http_server:distro:sys"
         ],
         "grant_capabilities": [],
         "public": true

--- a/src/new/templates/rust/no-ui/chat/pkg/manifest.json
+++ b/src/new/templates/rust/no-ui/chat/pkg/manifest.json
@@ -5,8 +5,7 @@
         "on_exit": "Restart",
         "request_networking": true,
         "request_capabilities": [
-            "http_server:distro:sys",
-            "net:distro:sys"
+            "http_server:distro:sys"
         ],
         "grant_capabilities": [],
         "public": true

--- a/src/new/templates/rust/no-ui/echo/pkg/manifest.json
+++ b/src/new/templates/rust/no-ui/echo/pkg/manifest.json
@@ -5,8 +5,7 @@
         "on_exit": "Restart",
         "request_networking": true,
         "request_capabilities": [
-            "http_server:distro:sys",
-            "net:distro:sys"
+            "http_server:distro:sys"
         ],
         "grant_capabilities": [],
         "public": true

--- a/src/new/templates/rust/no-ui/fibonacci/pkg/manifest.json
+++ b/src/new/templates/rust/no-ui/fibonacci/pkg/manifest.json
@@ -5,8 +5,7 @@
         "on_exit": "Restart",
         "request_networking": true,
         "request_capabilities": [
-            "http_server:distro:sys",
-            "net:distro:sys"
+            "http_server:distro:sys"
         ],
         "grant_capabilities": [],
         "public": true

--- a/src/new/templates/rust/no-ui/file_transfer/pkg/manifest.json
+++ b/src/new/templates/rust/no-ui/file_transfer/pkg/manifest.json
@@ -6,7 +6,6 @@
         "request_networking": true,
         "request_capabilities": [
             "http_server:distro:sys",
-            "net:distro:sys",
             "vfs:distro:sys"
         ],
         "grant_capabilities": [],

--- a/src/new/templates/rust/ui/chat/pkg/manifest.json
+++ b/src/new/templates/rust/ui/chat/pkg/manifest.json
@@ -6,7 +6,6 @@
         "request_networking": true,
         "request_capabilities": [
             "http_server:distro:sys",
-            "net:distro:sys",
             "vfs:distro:sys"
         ],
         "grant_capabilities": [],

--- a/src/run_tests/mod.rs
+++ b/src/run_tests/mod.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use dirs::home_dir;
 use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration};
-use toml;
 use tracing::{debug, info, instrument};
 
 use super::boot_fake_node::{compile_runtime, get_runtime_binary, run_runtime};


### PR DESCRIPTION
## Problem

1. Resolves #85
2. Resolves #87

## Solution

1. Remove `net:distro:sys` cap from templates.
2. Error out if the given language/template/ui combination doesn't exist.

## Docs Update

N/A

## Notes

None.