### PR TITLE
new: use top-level [workspace] Cargo.toml

### DIFF
--- a/src/new/templates/rust/no-ui/chat/Cargo.toml_
+++ b/src/new/templates/rust/no-ui/chat/Cargo.toml_
@@ -1,0 +1,10 @@
+[workspace]
+resolver = "2"
+members = [
+    "{package_name}",
+]
+
+[profile.release]
+panic = "abort"
+opt-level = "s"
+lto = true

--- a/src/new/templates/rust/no-ui/chat/{package_name}/Cargo.toml_
+++ b/src/new/templates/rust/no-ui/chat/{package_name}/Cargo.toml_
@@ -3,11 +3,6 @@ name = "{package_name}"
 version = "0.1.0"
 edition = "2021"
 
-[profile.release]
-panic = "abort"
-opt-level = "s"
-lto = true
-
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3.3"

--- a/src/new/templates/rust/no-ui/chat/{package_name}/src/lib.rs
+++ b/src/new/templates/rust/no-ui/chat/{package_name}/src/lib.rs
@@ -93,4 +93,3 @@ fn init(our: Address) {
         };
     }
 }
-

--- a/src/new/templates/rust/no-ui/echo/Cargo.toml_
+++ b/src/new/templates/rust/no-ui/echo/Cargo.toml_
@@ -1,0 +1,10 @@
+[workspace]
+resolver = "2"
+members = [
+    "{package_name}",
+]
+
+[profile.release]
+panic = "abort"
+opt-level = "s"
+lto = true

--- a/src/new/templates/rust/no-ui/echo/{package_name}/Cargo.toml_
+++ b/src/new/templates/rust/no-ui/echo/{package_name}/Cargo.toml_
@@ -3,11 +3,6 @@ name = "{package_name}"
 version = "0.1.0"
 edition = "2021"
 
-[profile.release]
-panic = "abort"
-opt-level = "s"
-lto = true
-
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3.3"

--- a/src/new/templates/rust/no-ui/fibonacci/Cargo.toml_
+++ b/src/new/templates/rust/no-ui/fibonacci/Cargo.toml_
@@ -1,0 +1,10 @@
+[workspace]
+resolver = "2"
+members = [
+    "{package_name}",
+]
+
+[profile.release]
+panic = "abort"
+opt-level = "s"
+lto = true

--- a/src/new/templates/rust/no-ui/fibonacci/{package_name}/Cargo.toml_
+++ b/src/new/templates/rust/no-ui/fibonacci/{package_name}/Cargo.toml_
@@ -3,11 +3,6 @@ name = "{package_name}"
 version = "0.1.0"
 edition = "2021"
 
-[profile.release]
-panic = "abort"
-opt-level = "s"
-lto = true
-
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3.3"

--- a/src/new/templates/rust/no-ui/file_transfer/Cargo.toml_
+++ b/src/new/templates/rust/no-ui/file_transfer/Cargo.toml_
@@ -1,0 +1,11 @@
+[workspace]
+resolver = "2"
+members = [
+    "{package_name}",
+    "worker",
+]
+
+[profile.release]
+panic = "abort"
+opt-level = "s"
+lto = true

--- a/src/new/templates/rust/no-ui/file_transfer/worker/Cargo.toml_
+++ b/src/new/templates/rust/no-ui/file_transfer/worker/Cargo.toml_
@@ -3,11 +3,6 @@ name = "worker"
 version = "0.1.0"
 edition = "2021"
 
-[profile.release]
-panic = "abort"
-opt-level = "s"
-lto = true
-
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3.3"

--- a/src/new/templates/rust/no-ui/file_transfer/{package_name}/Cargo.toml_
+++ b/src/new/templates/rust/no-ui/file_transfer/{package_name}/Cargo.toml_
@@ -3,11 +3,6 @@ name = "{package_name}"
 version = "0.1.0"
 edition = "2021"
 
-[profile.release]
-panic = "abort"
-opt-level = "s"
-lto = true
-
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3.3"


### PR DESCRIPTION
## Problem

#90: use top-level Cargo.toml in templates with `[workspace]` field.

## Solution

Resolves #90 by adding that Cargo.toml.

## Docs Update

N/A

## Notes

Please try creating a template and let me know if this change makes the Rust analyzer happier. E.g., something like

```
# Install this branch's kit
cargo install --path .

# Create the package from template.
kit n foo -t file_transfer

# Edit files like file_transfer/file_transfer/src/lib.rs or file_transfer/worker/src/lib.rs
```