### PR TITLE
dev-ui should run `npm run dev` not `npm start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For details and examples, please see [https://github.com/kinode-dao/core_tests](
 ## UI Development
 
 The simplest way to work on the UI is to use `kit dev-ui` which develops against a running node.
-Under the hood, `kit dev-ui` is just `cd ui && npm install && npm start`.
+Under the hood, `kit dev-ui` is just `cd ui && npm install && npm run dev`.
 
 The UI should open on port `3000` (or next available port) and will proxy all websocket and HTTP requests to `http://localhost:8080` by default.
 You can choose to proxy to any URL using the `-u` flag:
@@ -85,7 +85,7 @@ kit dev-ui my_package -u http://localhost:8081
 ```
 This is the same as prepending the environment variable:
 ```bash
-VITE_NODE_URL=http://localhost:8081 npm start
+VITE_NODE_URL=http://localhost:8081 npm run dev
 ```
 
 NodeJS (v18 or higher) and NPM are required to build and develop the UI.

--- a/src/dev_ui/mod.rs
+++ b/src/dev_ui/mod.rs
@@ -21,23 +21,23 @@ pub fn execute(package_dir: &Path, url: &str, skip_deps_check: bool) -> anyhow::
         info!("UI directory found, running npm install...");
 
         let install = "npm install".to_string();
-        let start = "npm start".to_string();
-        let (install, start) = valid_node
+        let dev = "npm run dev".to_string();
+        let (install, dev) = valid_node
             .map(|valid_node| {(
                 format!("source ~/.nvm/nvm.sh && nvm use {} && {}", valid_node, install),
-                format!("source ~/.nvm/nvm.sh && nvm use {} && {}", valid_node, start),
+                format!("source ~/.nvm/nvm.sh && nvm use {} && {}", valid_node, dev),
             )})
-            .unwrap_or_else(|| (install, start));
+            .unwrap_or_else(|| (install, dev));
 
         run_command(Command::new("bash")
             .args(&["-c", &install])
             .current_dir(&ui_path)
         )?;
 
-        info!("Running npm start...");
+        info!("Running npm run dev...");
 
         run_command(Command::new("bash")
-            .args(&["-c", &start])
+            .args(&["-c", &dev])
             .env("VITE_NODE_URL", url)
             .current_dir(&ui_path)
         )?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -483,7 +483,7 @@ async fn make_app(current_dir: &std::ffi::OsString) -> anyhow::Result<Command> {
             )
         )
         .subcommand(Command::new("dev-ui")
-            .about("Start the web UI development server with hot reloading (same as `cd ui && npm i && npm start`)")
+            .about("Start the web UI development server with hot reloading (same as `cd ui && npm i && npm run dev`)")
             .visible_alias("d")
             .arg(Arg::new("DIR")
                 .action(ArgAction::Set)

--- a/src/new/templates/ui/chat/ui/README.md
+++ b/src/new/templates/ui/chat/ui/README.md
@@ -10,7 +10,7 @@ If you have multiple processes in `manifest.json`, make sure the first process w
 
 ## Development
 
-Run `npm i` and then `npm start` to start working on the UI.
+Run `npm i` and then `npm run dev` to start working on the UI.
 
 You may see an error:
 


### PR DESCRIPTION
## Problem

- The `npm start` command is conventionally used to start an application in its **production** environment
- The `npm run dev` command is a convention for starting an application in its **development** environment
- dev-ui runs `npm start` when it should be running `npm run dev`

## Solution

This PR is not a complete solution since it doesn't handle the production case AFAICT. A complete solution shouldn't naively replace `npm start` with `npm run dev`, but conditionally run one over the other depending on wether `execute` is called in production or development. I'm hoping someone with a higher-level view of `kit` can help implement that conditional.

## Docs Update

The `Arguments` section on this page would need updating: https://book.kinode.org/kit/dev-ui.html

## Notes

The reason this hasn't been a problem so far is because the Kinode template apps all use Vite, and Vite doesn't discriminate between start and dev even though you will find both scripts in its `package.json`:

```json
"scripts": {
  "dev": "vite --port 3000",
  "start": "vite --port 3000"
}
```

But not all build tools are this laissez-faire. The React framework we are using for our app, [NextJS](https://nextjs.org/docs/getting-started/installation#run-the-development-server), which uses Webpack under the hood, requires you to use a distinct `dev` command, and so does Webpack's rust-powered successor, [Turbopack](https://turbo.build/pack/docs#existing-projects). If nothing else, `dev` vs `start` is a pretty established convention in web dev.