### PR TITLE
fix: use ws-port flag with runtime, default value 9000

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "kit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/src/boot_fake_node/mod.rs
+++ b/src/boot_fake_node/mod.rs
@@ -335,7 +335,7 @@ pub fn run_runtime(
     let verbosity = format!("{}", verbosity);
     let mut full_args = vec![
         home.to_str().unwrap(), "--port", port.as_str(),
-        "--network-router-port", network_router_port.as_str(),
+        "--ws-port", network_router_port.as_str(),
         "--verbosity", verbosity.as_str(),
     ];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -373,7 +373,7 @@ async fn make_app(current_dir: &std::ffi::OsString) -> anyhow::Result<Command> {
                 .action(ArgAction::Set)
                 .long("network-router-port")
                 .help("The port to run the network router on (or to connect to)")
-                .default_value("9001")
+                .default_value("9000")
                 .value_parser(value_parser!(u16))
             )
             .arg(Arg::new("RPC_ENDPOINT")


### PR DESCRIPTION
## Problem

In PR https://github.com/kinode-dao/kinode/pull/282 of the runtime, the flag for passing a ws-networking port is changed to `--ws-port`. The old name of `--network-router-port` was not suitable because nodes have multiple networking protocols available to them. We need to specify that this is the port for the WebSockets protocol.

## Solution

This PR changes `kit` to use the new flag. It also sets the default port to 9000, to match the behavior of the runtime.

## Notes

Do not merge until the PR linked above is added to a new runtime release (will be 0.6.2)