### PR TITLE
run `cargo` with `--color=always`

### DIFF
--- a/src/boot_fake_node/mod.rs
+++ b/src/boot_fake_node/mod.rs
@@ -79,6 +79,7 @@ pub fn compile_runtime(path: &Path, release: bool) -> anyhow::Result<()> {
         "kinode",
         "--features",
         "simulation-mode",
+        "--color=always",
     ];
     if release {
         args.push("--release");

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -230,6 +230,7 @@ async fn compile_rust_wasm_process(
          "wasm32-wasi",
          "--target-dir",
          "target",
+         "--color=always"
     ];
     if !features.is_empty() {
         args.push("--features");

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -227,8 +227,13 @@ fn call_rustup(arg: &str) -> anyhow::Result<()> {
 
 #[instrument(level = "trace", err, skip_all)]
 fn call_cargo(arg: &str) -> anyhow::Result<()> {
+    let command = if arg.contains("--color=always") {
+        format!("cargo {}", arg)
+    } else {
+        format!("cargo --color=always {}", arg)
+    };
     run_command(Command::new("bash")
-        .args(&["-c", &format!("cargo {}", arg)])
+        .args(&["-c", &command])
     )
 }
 

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -9,6 +9,7 @@ pub fn execute(mut user_args: Vec<String>, branch: &str) -> anyhow::Result<()> {
     let mut args: Vec<String> = vec!["install",
         "--git", "https://github.com/kinode-dao/kit",
         "--branch", branch,
+        "--color=always",
     ]
         .iter()
         .map(|v| v.to_string())


### PR DESCRIPTION
## Problem

Resolves #102

## Solution

The command called by `std::process::Command` can tell if it is being printed to terminal -- like when we use `Stdio::inherit` -- vs when it is being piped -- like when we use `Stdio::piped`. We changed to piping and lost the color. Fix by passing `--color=always` to `cargo`.

## Docs Update

N/A

## Notes

FYI @tadad 