### PR TITLE
only print errors once (using color-eyre)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "kit"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
+name = "color-eyre"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,6 +808,16 @@ checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -1173,6 +1210,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,6 +1345,7 @@ dependencies = [
  "anyhow",
  "base64",
  "clap",
+ "color-eyre",
  "dirs",
  "fs-err",
  "futures-util",
@@ -1321,6 +1365,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-appender",
+ "tracing-error",
  "tracing-subscriber",
  "walkdir",
  "zip",
@@ -1613,6 +1658,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parity-scale-codec"
@@ -2679,6 +2730,16 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kit"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [build-dependencies]
@@ -8,9 +8,9 @@ anyhow = "1.0"
 git2 = "0.18"
 
 [dependencies]
-anyhow = "1.0"
 base64 = "0.21"
 clap = { version = "4.4", features = ["cargo", "string"] }
+color-eyre = { version = "0.6", features = ["capture-spantrace"] }
 dirs = "5.0"
 fs-err = "2.11"
 futures-util = "0.3"
@@ -36,6 +36,7 @@ tokio-tungstenite = "*"
 toml = "0.8"
 tracing = "0.1"
 tracing-appender = "0.2"
+tracing-error = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "std"] }
 walkdir = "2.4"
 zip = "0.6"

--- a/src/build_start_package/mod.rs
+++ b/src/build_start_package/mod.rs
@@ -1,11 +1,12 @@
 use std::path::Path;
 
+use color_eyre::Result;
 use tracing::instrument;
 
 use crate::build;
 use crate::start_package;
 
-#[instrument(level = "trace", err(Debug), skip_all)]
+#[instrument(level = "trace", skip_all)]
 pub async fn execute(
     package_dir: &Path,
     no_ui: bool,
@@ -13,7 +14,7 @@ pub async fn execute(
     url: &str,
     skip_deps_check: bool,
     features: &str,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     build::execute(package_dir, no_ui, ui_only, skip_deps_check, features).await?;
     start_package::execute(package_dir, url).await?;
     Ok(())

--- a/src/dev_ui/mod.rs
+++ b/src/dev_ui/mod.rs
@@ -1,18 +1,19 @@
 use std::path::Path;
 use std::process::Command;
 
+use color_eyre::{eyre::eyre, Result};
 use tracing::{info, instrument};
 
 use crate::build::run_command;
 use crate::setup::{check_js_deps, get_deps, get_newest_valid_node_version};
 
-#[instrument(level = "trace", err(Debug), skip_all)]
+#[instrument(level = "trace", skip_all)]
 pub fn execute(
     package_dir: &Path,
     url: &str,
     skip_deps_check: bool,
     release: bool,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     if !skip_deps_check {
         let deps = check_js_deps()?;
         get_deps(deps)?;
@@ -53,9 +54,7 @@ pub fn execute(
                 .current_dir(&ui_path),
         )?;
     } else {
-        return Err(anyhow::anyhow!(
-            "'ui' directory not found or 'ui/package.json' does not exist"
-        ));
+        return Err(eyre!("'ui' directory not found or 'ui/package.json' does not exist"));
     }
 
     Ok(())

--- a/src/remove_package/mod.rs
+++ b/src/remove_package/mod.rs
@@ -1,19 +1,20 @@
 use std::path::Path;
 use std::process;
 
+use color_eyre::Result;
 use fs_err as fs;
 use tracing::instrument;
 
 use crate::inject_message;
 use crate::start_package::interact_with_package;
 
-#[instrument(level = "trace", err(Debug), skip_all)]
+#[instrument(level = "trace", skip_all)]
 pub async fn execute(
     project_dir: &Path,
     url: &str,
     arg_package_name: Option<&str>,
     arg_publisher: Option<&str>,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let (package_name, publisher): (String, String) = match (arg_package_name, arg_publisher) {
         (Some(package_name), Some(publisher)) => (package_name.into(), publisher.into()),
         _ => {

--- a/src/reset_cache/mod.rs
+++ b/src/reset_cache/mod.rs
@@ -1,12 +1,13 @@
 use std::path::PathBuf;
 
+use color_eyre::Result;
 use fs_err as fs;
 use tracing::{info, instrument};
 
 use crate::KIT_CACHE;
 
-#[instrument(level = "trace", err(Debug), skip_all)]
-fn reset_cache() -> anyhow::Result<()> {
+#[instrument(level = "trace", skip_all)]
+fn reset_cache() -> Result<()> {
     info!("Resetting cache...");
     let path = PathBuf::from(KIT_CACHE);
     if path.exists() {
@@ -16,7 +17,7 @@ fn reset_cache() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[instrument(level = "trace", err(Debug), skip_all)]
-pub fn execute() -> anyhow::Result<()> {
+#[instrument(level = "trace", skip_all)]
+pub fn execute() -> Result<()> {
     reset_cache()
 }

--- a/src/run_tests/mod.rs
+++ b/src/run_tests/mod.rs
@@ -55,10 +55,9 @@ fn make_node_names(nodes: Vec<Node>) -> Result<Vec<String>> {
                 }
                 Some(base)
             })
-            .ok_or(eyre!(
-                "run_tests:make_node_names: did not find basename for {:?}",
-                node.home,
-            ))
+            .ok_or_else(|| {
+                eyre!("run_tests:make_node_names: did not find basename for {:?}", node.home)
+            })
         )
         .collect()
 }

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -1,13 +1,14 @@
 use std::process::Command;
 
+use color_eyre::Result;
 use fs_err as fs;
 use tracing::instrument;
 
 use crate::KIT_CACHE;
 use crate::build;
 
-#[instrument(level = "trace", err(Debug), skip_all)]
-pub fn execute(mut user_args: Vec<String>, branch: &str) -> anyhow::Result<()> {
+#[instrument(level = "trace", skip_all)]
+pub fn execute(mut user_args: Vec<String>, branch: &str) -> Result<()> {
     let mut args: Vec<String> = vec!["install",
         "--git", "https://github.com/kinode-dao/kit",
         "--branch", branch,


### PR DESCRIPTION
## Problem

Resolves #119

## Solution

* Use [color-eyre](https://github.com/eyre-rs/color-eyre)
* Swap out [anyhow](https://github.com/dtolnay/anyhow)
* Use [tracing_error](https://docs.rs/tracing-error/latest/tracing_error/) and `#[instrument]` to accumulate `SpanTrace` and print at top-level in `main()` rather than `#[instrument(err)]` to print at every function site

## Docs Update

N/A

## Notes

A step towards #104 : we'll use `.with_suggestions()` and `.wrap_err_with()` methods to de-nerd-ify errors.