### PR TITLE
print zip file hash during start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,6 +1359,7 @@ dependencies = [
  "semver 1.0.20",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
  "tokio",
  "tokio-tungstenite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ rmp-serde = "1.1.2"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10.8"
 thiserror = "1.0"
 tokio = { version = "1.28", features = [
     "fs",

--- a/src/start_package/mod.rs
+++ b/src/start_package/mod.rs
@@ -126,9 +126,7 @@ pub async fn execute(package_dir: &Path, url: &str) -> Result<()> {
     file.read_to_end(&mut buffer)?;
     hasher.update(&buffer);
     let hash_result = hasher.finalize();
-    let hash_hex = format!("{:x}", hash_result);
-    println!("package zip hash: {}", hash_hex);
-
+    info!("package zip hash: {:x}", hash_result);
     // Create and send new package request
     let new_pkg_request = new_package(
         None,

--- a/src/start_package/mod.rs
+++ b/src/start_package/mod.rs
@@ -1,3 +1,4 @@
+use sha2::{Sha256, Digest};
 use std::io::{Read, Write};
 use std::path::Path;
 
@@ -117,6 +118,16 @@ pub async fn execute(package_dir: &Path, url: &str) -> Result<()> {
     fs::create_dir_all(&target_dir)?;
     let zip_filename = target_dir.join(&pkg_publisher).with_extension("zip");
     zip_directory(&pkg_dir, &zip_filename.to_str().unwrap())?;
+
+
+    let mut file = fs::File::open(&zip_filename)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = Vec::new();
+    file.read_to_end(&mut buffer)?;
+    hasher.update(&buffer);
+    let hash_result = hasher.finalize();
+    let hash_hex = format!("{:x}", hash_result);
+    println!("package zip hash: {}", hash_hex);
 
     // Create and send new package request
     let new_pkg_request = new_package(


### PR DESCRIPTION
## Problem
for app store publishing, it's a slight hassle to find the package zip hash from inside of the vfs of the node you're trying to serve it from.

## Solution

print it upon start (perhaps write it into `metadata.json` automatically too? (this seems like too much to me, but perhaps gate behind a flag) 

## Docs Update

[Corresponding docs PR](https://github.com/kinode-dao/kinode-book/pull/my-pr-number)

## Notes
```
kit s
simtester:template.os
package zip hash: be8a31d6fc1fcea9395c10ecf3486fdde3c86ee61a8ab7f15211717d555fb474
Successfully installed package simtester:template.os on node at http://localhost:8080
```