### PR TITLE
add scripts

### DIFF
--- a/src/boot_fake_node/mod.rs
+++ b/src/boot_fake_node/mod.rs
@@ -487,6 +487,7 @@ pub async fn execute(
         process_id: runtime_process.id().unwrap() as i32,
         home: node_home.clone(),
         anvil_process: anvil_process.map(|ap| ap.id() as i32),
+        other_processes: vec![],
     });
     drop(node_cleanup_infos);
 

--- a/src/boot_real_node/mod.rs
+++ b/src/boot_real_node/mod.rs
@@ -94,6 +94,7 @@ pub async fn execute(
         process_id: runtime_process.id().unwrap() as i32,
         home: node_home.clone(),
         anvil_process: None,
+        other_processes: vec![],
     });
     drop(node_cleanup_infos);
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -97,12 +97,12 @@ pub fn run_command(cmd: &mut Command, verbose: bool) -> Result<Option<(String, S
         )))
     } else {
         Err(eyre!(
-            "Command `{} {:?}` failed with exit code {}\nstdout: {}\nstderr: {}",
+            "Command `{} {:?}` failed with exit code {:?}\nstdout: {}\nstderr: {}",
             cmd.get_program().to_str().unwrap(),
             cmd.get_args()
                 .map(|a| a.to_str().unwrap())
                 .collect::<Vec<_>>(),
-            output.status.code().unwrap(),
+            output.status.code(),
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr),
         ))

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -46,6 +46,43 @@ struct CargoPackage {
 }
 
 #[instrument(level = "trace", skip_all)]
+pub fn has_feature(cargo_toml_path: &str, feature: &str) -> Result<bool> {
+    let cargo_toml_content = fs::read_to_string(cargo_toml_path)?;
+    let cargo_toml: toml::Value = cargo_toml_content.parse()?;
+
+    if let Some(features) = cargo_toml.get("features").and_then(|f| f.as_table()) {
+        Ok(features.contains_key(feature))
+    } else {
+        Ok(false)
+    }
+}
+
+#[instrument(level = "trace", skip_all)]
+pub fn remove_missing_features(
+    cargo_toml_path: &Path,
+    features: Vec<&str>,
+) -> Result<Vec<String>> {
+    let cargo_toml_content = fs::read_to_string(cargo_toml_path)?;
+    let cargo_toml: toml::Value = cargo_toml_content.parse()?;
+    let Some(cargo_features) = cargo_toml.get("features").and_then(|f| f.as_table()) else {
+        return Ok(vec![]);
+    };
+
+    Ok(features
+        .iter()
+        .filter_map(|f| {
+            let f = f.to_string();
+            if cargo_features.contains_key(&f) {
+                Some(f)
+            } else {
+                None
+            }
+        })
+        .collect()
+    )
+}
+
+#[instrument(level = "trace", skip_all)]
 pub fn run_command(cmd: &mut Command, verbose: bool) -> Result<Option<(String, String)>> {
     if verbose {
         let mut child = cmd.spawn()?;
@@ -324,6 +361,17 @@ async fn compile_rust_wasm_process(
         "target",
         "--color=always",
     ];
+    let test_only = features == "test";
+    let features: Vec<&str> = features.split(',').collect();
+    let original_length = features.len();
+    let features = remove_missing_features(
+        &process_dir.join("Cargo.toml"),
+        features,
+    )?;
+    if !test_only && original_length != features.len() {
+        info!("process {:?} missing features; using {:?}", process_dir, features);
+    };
+    let features = features.join(",");
     if !features.is_empty() {
         args.push("--features");
         args.push(&features);
@@ -492,17 +540,6 @@ async fn build_wit_dir(
     for (file_name, contents) in apis {
         fs::write(wit_dir.join(file_name), contents)?;
     }
-
-    //let src_dir = process_dir.join("src");
-    //for entry in src_dir.read_dir()? {
-    //    let entry = entry?;
-    //    let path = entry.path();
-    //    if Some("wit") == path.extension().and_then(|s| s.to_str()) {
-    //        if let Some(file_name) = path.file_name().and_then(|s| s.to_str()) {
-    //            fs::copy(&path, wit_dir.join(file_name))?;
-    //        }
-    //    }
-    //}
     Ok(())
 }
 

--- a/src/new/templates/test/chat/tests.toml
+++ b/src/new/templates/test/chat/tests.toml
@@ -8,6 +8,8 @@ setup_package_paths = [".."]
 test_packages = [
     { path = "{package_name}_test", grant_capabilities = ["{package_name}:{package_name}:{publisher}"] },
 ]
+setup_scripts = []
+test_scripts = []
 timeout_secs = 5
 fakechain_router = 8545
 

--- a/src/new/templates/test/chat/tests.toml
+++ b/src/new/templates/test/chat/tests.toml
@@ -5,7 +5,9 @@ runtime_build_release = false
 
 
 [[tests]]
-setup_package_paths = [".."]
+setup_packages = [
+    { path = "..", run = true }
+]
 setup_scripts = []
 test_packages = [
     { path = "{package_name}_test", grant_capabilities = ["{package_name}:{package_name}:{publisher}"] },

--- a/src/new/templates/test/chat/tests.toml
+++ b/src/new/templates/test/chat/tests.toml
@@ -9,9 +9,7 @@ setup_packages = [
     { path = "..", run = true }
 ]
 setup_scripts = []
-test_packages = [
-    { path = "{package_name}_test", grant_capabilities = ["{package_name}:{package_name}:{publisher}"] },
-]
+test_package_paths = ["{package_name}_test"]
 test_scripts = []
 timeout_secs = 5
 fakechain_router = 8545
@@ -20,10 +18,10 @@ fakechain_router = 8545
 port = 8080
 home = "home/first"
 fake_node_name = "first.dev"
-runtime_verbosity = 0
+runtime_verbosity = 2
 
 [[tests.nodes]]
 port = 8081
 home = "home/second"
 fake_node_name = "second.dev"
-runtime_verbosity = 0
+runtime_verbosity = 2

--- a/src/new/templates/test/chat/tests.toml
+++ b/src/new/templates/test/chat/tests.toml
@@ -1,14 +1,15 @@
 runtime = { FetchVersion = "latest" }
 # runtime = { RepoPath = "~/git/kinode" }
+persist_home = false
 runtime_build_release = false
 
 
 [[tests]]
 setup_package_paths = [".."]
+setup_scripts = []
 test_packages = [
     { path = "{package_name}_test", grant_capabilities = ["{package_name}:{package_name}:{publisher}"] },
 ]
-setup_scripts = []
 test_scripts = []
 timeout_secs = 5
 fakechain_router = 8545

--- a/src/new/templates/test/chat/{package_name}_test/pkg/manifest.json
+++ b/src/new/templates/test/chat/{package_name}_test/pkg/manifest.json
@@ -4,7 +4,9 @@
         "process_wasm_path": "/{package_name}_test.wasm",
         "on_exit": "Restart",
         "request_networking": false,
-        "request_capabilities": [],
+        "request_capabilities": [
+            "{package_name}:{package_name}:{publisher}"
+        ],
         "grant_capabilities": [
             "{package_name}:{package_name}:{publisher}"
         ],

--- a/src/new/templates/test/chat/{package_name}_test/{package_name}_test/src/tester_lib.rs
+++ b/src/new/templates/test/chat/{package_name}_test/{package_name}_test/src/tester_lib.rs
@@ -1,6 +1,5 @@
-use crate::kinode::process::tester::{
-    Response as TesterResponse, FailResponse,
-};
+#[allow(unused_imports)]
+use crate::kinode::process::tester::{FailResponse, Response as TesterResponse};
 
 #[macro_export]
 macro_rules! fail {

--- a/src/new/templates/test/echo/tests.toml
+++ b/src/new/templates/test/echo/tests.toml
@@ -8,6 +8,8 @@ setup_package_paths = [".."]
 test_packages = [
     { path = "{package_name}_test", grant_capabilities = ["{package_name}:{package_name}:{publisher}"] },
 ]
+setup_scripts = []
+test_scripts = []
 timeout_secs = 5
 fakechain_router = 8545
 

--- a/src/new/templates/test/echo/tests.toml
+++ b/src/new/templates/test/echo/tests.toml
@@ -5,7 +5,9 @@ runtime_build_release = false
 
 
 [[tests]]
-setup_package_paths = [".."]
+setup_packages = [
+    { path = "..", run = true }
+]
 setup_scripts = []
 test_packages = [
     { path = "{package_name}_test", grant_capabilities = ["{package_name}:{package_name}:{publisher}"] },

--- a/src/new/templates/test/echo/tests.toml
+++ b/src/new/templates/test/echo/tests.toml
@@ -1,14 +1,15 @@
 runtime = { FetchVersion = "latest" }
 # runtime = { RepoPath = "~/git/kinode" }
+persist_home = false
 runtime_build_release = false
 
 
 [[tests]]
 setup_package_paths = [".."]
+setup_scripts = []
 test_packages = [
     { path = "{package_name}_test", grant_capabilities = ["{package_name}:{package_name}:{publisher}"] },
 ]
-setup_scripts = []
 test_scripts = []
 timeout_secs = 5
 fakechain_router = 8545

--- a/src/new/templates/test/echo/tests.toml
+++ b/src/new/templates/test/echo/tests.toml
@@ -9,9 +9,7 @@ setup_packages = [
     { path = "..", run = true }
 ]
 setup_scripts = []
-test_packages = [
-    { path = "{package_name}_test", grant_capabilities = ["{package_name}:{package_name}:{publisher}"] },
-]
+test_package_paths = ["{package_name}_test"]
 test_scripts = []
 timeout_secs = 5
 fakechain_router = 8545
@@ -20,4 +18,4 @@ fakechain_router = 8545
 port = 8080
 home = "home/first"
 fake_node_name = "first.dev"
-runtime_verbosity = 0
+runtime_verbosity = 2

--- a/src/new/templates/test/echo/{package_name}_test/pkg/manifest.json
+++ b/src/new/templates/test/echo/{package_name}_test/pkg/manifest.json
@@ -4,7 +4,9 @@
         "process_wasm_path": "/{package_name}_test.wasm",
         "on_exit": "Restart",
         "request_networking": false,
-        "request_capabilities": [],
+        "request_capabilities": [
+            "{package_name}:{package_name}:{publisher}"
+        ],
         "grant_capabilities": [
             "{package_name}:{package_name}:{publisher}"
         ],

--- a/src/new/templates/test/echo/{package_name}_test/{package_name}_test/src/lib.rs
+++ b/src/new/templates/test/echo/{package_name}_test/{package_name}_test/src/lib.rs
@@ -1,6 +1,10 @@
-use crate::kinode::process::tester::{Request as TesterRequest, Response as TesterResponse, RunRequest, FailResponse};
+use crate::kinode::process::tester::{
+    FailResponse, Request as TesterRequest, Response as TesterResponse, RunRequest,
+};
 
-use kinode_process_lib::{await_message, call_init, print_to_terminal, println, Address, ProcessId, Request, Response};
+use kinode_process_lib::{
+    await_message, call_init, print_to_terminal, Address, ProcessId, Request, Response,
+};
 
 mod tester_lib;
 
@@ -11,7 +15,7 @@ wit_bindgen::generate!({
     additional_derives: [PartialEq, serde::Deserialize, serde::Serialize, process_macros::SerdeJsonInto],
 });
 
-fn handle_message (our: &Address) -> anyhow::Result<()> {
+fn handle_message(our: &Address) -> anyhow::Result<()> {
     let message = await_message().unwrap();
 
     if !message.is_request() {
@@ -38,15 +42,15 @@ fn handle_message (our: &Address) -> anyhow::Result<()> {
 
     // Send
     print_to_terminal(0, "{package_name}_test: b");
-    let message: String = "hello".into();
     let response = Request::new()
         .target(our_echo_address)
         .body(serde_json::to_vec("test")?)
-        .send_and_await_response(15)?.unwrap();
-    if response.is_request() { fail!("{package_name}_test"); };
-    if serde_json::json!("Ack") != serde_json::from_slice::<serde_json::Value>(
-        response.body()
-    )? {
+        .send_and_await_response(15)?
+        .unwrap();
+    if response.is_request() {
+        fail!("{package_name}_test");
+    };
+    if serde_json::json!("Ack") != serde_json::from_slice::<serde_json::Value>(response.body())? {
         fail!("{package_name}_test");
     };
 
@@ -64,12 +68,12 @@ fn init(our: Address) {
 
     loop {
         match handle_message(&our) {
-            Ok(()) => {},
+            Ok(()) => {}
             Err(e) => {
                 print_to_terminal(0, format!("{package_name}_test: error: {e:?}").as_str());
 
                 fail!("{package_name}_test");
-            },
+            }
         };
     }
 }

--- a/src/new/templates/test/echo/{package_name}_test/{package_name}_test/src/tester_lib.rs
+++ b/src/new/templates/test/echo/{package_name}_test/{package_name}_test/src/tester_lib.rs
@@ -1,6 +1,5 @@
-use crate::kinode::process::tester::{
-    Response as TesterResponse, FailResponse,
-};
+#[allow(unused_imports)]
+use crate::kinode::process::tester::{FailResponse, Response as TesterResponse};
 
 #[macro_export]
 macro_rules! fail {

--- a/src/new/templates/test/fibonacci/tests.toml
+++ b/src/new/templates/test/fibonacci/tests.toml
@@ -8,6 +8,8 @@ setup_package_paths = [".."]
 test_packages = [
     { path = "{package_name}_test", grant_capabilities = ["{package_name}:{package_name}:{publisher}"] },
 ]
+setup_scripts = []
+test_scripts = []
 timeout_secs = 5
 fakechain_router = 8545
 

--- a/src/new/templates/test/fibonacci/tests.toml
+++ b/src/new/templates/test/fibonacci/tests.toml
@@ -5,7 +5,9 @@ runtime_build_release = false
 
 
 [[tests]]
-setup_package_paths = [".."]
+setup_packages = [
+    { path = "..", run = true }
+]
 setup_scripts = []
 test_packages = [
     { path = "{package_name}_test", grant_capabilities = ["{package_name}:{package_name}:{publisher}"] },

--- a/src/new/templates/test/fibonacci/tests.toml
+++ b/src/new/templates/test/fibonacci/tests.toml
@@ -1,14 +1,15 @@
 runtime = { FetchVersion = "latest" }
 # runtime = { RepoPath = "~/git/kinode" }
+persist_home = false
 runtime_build_release = false
 
 
 [[tests]]
 setup_package_paths = [".."]
+setup_scripts = []
 test_packages = [
     { path = "{package_name}_test", grant_capabilities = ["{package_name}:{package_name}:{publisher}"] },
 ]
-setup_scripts = []
 test_scripts = []
 timeout_secs = 5
 fakechain_router = 8545

--- a/src/new/templates/test/fibonacci/tests.toml
+++ b/src/new/templates/test/fibonacci/tests.toml
@@ -9,9 +9,7 @@ setup_packages = [
     { path = "..", run = true }
 ]
 setup_scripts = []
-test_packages = [
-    { path = "{package_name}_test", grant_capabilities = ["{package_name}:{package_name}:{publisher}"] },
-]
+test_package_paths = ["{package_name}_test"]
 test_scripts = []
 timeout_secs = 5
 fakechain_router = 8545
@@ -20,4 +18,4 @@ fakechain_router = 8545
 port = 8080
 home = "home/first"
 fake_node_name = "first.dev"
-runtime_verbosity = 0
+runtime_verbosity = 2

--- a/src/new/templates/test/fibonacci/{package_name}_test/pkg/manifest.json
+++ b/src/new/templates/test/fibonacci/{package_name}_test/pkg/manifest.json
@@ -4,7 +4,9 @@
         "process_wasm_path": "/{package_name}_test.wasm",
         "on_exit": "Restart",
         "request_networking": false,
-        "request_capabilities": [],
+        "request_capabilities": [
+            "{package_name}:{package_name}:{publisher}"
+        ],
         "grant_capabilities": [
             "{package_name}:{package_name}:{publisher}"
         ],

--- a/src/new/templates/test/fibonacci/{package_name}_test/{package_name}_test/src/tester_lib.rs
+++ b/src/new/templates/test/fibonacci/{package_name}_test/{package_name}_test/src/tester_lib.rs
@@ -1,6 +1,5 @@
-use crate::kinode::process::tester::{
-    Response as TesterResponse, FailResponse,
-};
+#[allow(unused_imports)]
+use crate::kinode::process::tester::{FailResponse, Response as TesterResponse};
 
 #[macro_export]
 macro_rules! fail {

--- a/src/new/templates/test/file_transfer/tests.toml
+++ b/src/new/templates/test/file_transfer/tests.toml
@@ -8,6 +8,8 @@ setup_package_paths = [".."]
 test_packages = [
     { path = "{package_name}_test", grant_capabilities = ["{package_name}:{package_name}:{publisher}"] },
 ]
+setup_scripts = []
+test_scripts = []
 timeout_secs = 5
 fakechain_router = 8545
 

--- a/src/new/templates/test/file_transfer/tests.toml
+++ b/src/new/templates/test/file_transfer/tests.toml
@@ -5,7 +5,9 @@ runtime_build_release = false
 
 
 [[tests]]
-setup_package_paths = [".."]
+setup_packages = [
+    { path = "..", run = true }
+]
 setup_scripts = []
 test_packages = [
     { path = "{package_name}_test", grant_capabilities = ["{package_name}:{package_name}:{publisher}"] },

--- a/src/new/templates/test/file_transfer/tests.toml
+++ b/src/new/templates/test/file_transfer/tests.toml
@@ -9,9 +9,7 @@ setup_packages = [
     { path = "..", run = true }
 ]
 setup_scripts = []
-test_packages = [
-    { path = "{package_name}_test", grant_capabilities = ["{package_name}:{package_name}:{publisher}"] },
-]
+test_package_paths = ["{package_name}_test"]
 test_scripts = []
 timeout_secs = 5
 fakechain_router = 8545
@@ -20,10 +18,10 @@ fakechain_router = 8545
 port = 8080
 home = "home/first"
 fake_node_name = "first.dev"
-runtime_verbosity = 0
+runtime_verbosity = 2
 
 [[tests.nodes]]
 port = 8081
 home = "home/second"
 fake_node_name = "second.dev"
-runtime_verbosity = 0
+runtime_verbosity = 2

--- a/src/new/templates/test/file_transfer/tests.toml
+++ b/src/new/templates/test/file_transfer/tests.toml
@@ -1,14 +1,15 @@
 runtime = { FetchVersion = "latest" }
 # runtime = { RepoPath = "~/git/kinode" }
+persist_home = false
 runtime_build_release = false
 
 
 [[tests]]
 setup_package_paths = [".."]
+setup_scripts = []
 test_packages = [
     { path = "{package_name}_test", grant_capabilities = ["{package_name}:{package_name}:{publisher}"] },
 ]
-setup_scripts = []
 test_scripts = []
 timeout_secs = 5
 fakechain_router = 8545

--- a/src/new/templates/test/file_transfer/{package_name}_test/pkg/manifest.json
+++ b/src/new/templates/test/file_transfer/{package_name}_test/pkg/manifest.json
@@ -4,7 +4,9 @@
         "process_wasm_path": "/{package_name}_test.wasm",
         "on_exit": "Restart",
         "request_networking": false,
-        "request_capabilities": [],
+        "request_capabilities": [
+            "{package_name}:{package_name}:{publisher}"
+        ],
         "grant_capabilities": [
             "{package_name}:{package_name}:{publisher}"
         ],

--- a/src/new/templates/test/file_transfer/{package_name}_test/{package_name}_test/src/tester_lib.rs
+++ b/src/new/templates/test/file_transfer/{package_name}_test/{package_name}_test/src/tester_lib.rs
@@ -1,6 +1,5 @@
-use crate::kinode::process::tester::{
-    Response as TesterResponse, FailResponse,
-};
+#[allow(unused_imports)]
+use crate::kinode::process::tester::{FailResponse, Response as TesterResponse};
 
 #[macro_export]
 macro_rules! fail {

--- a/src/run_tests/cleanup.rs
+++ b/src/run_tests/cleanup.rs
@@ -93,6 +93,7 @@ pub async fn cleanup(
         process_id,
         home,
         anvil_process,
+        other_processes,
     } in node_cleanup_infos.iter_mut().rev()
     {
         // Send Ctrl-C to the process
@@ -116,6 +117,10 @@ pub async fn cleanup(
             clean_process_by_pid(*anvil);
             info!("Cleaned up anvil fakechain.");
         }
+
+        other_processes
+            .iter()
+            .for_each(|pid| clean_process_by_pid(*pid));
 
         if let Some(ref mut nh) = node_handles {
             if let Some(mut node_handle) = nh.next() {

--- a/src/run_tests/cleanup.rs
+++ b/src/run_tests/cleanup.rs
@@ -88,6 +88,10 @@ pub async fn cleanup(
         }
     };
 
+    let _ = send_to_kill.send(
+        should_print_std.is_none() || should_print_std.is_some_and(|b| b)
+    );
+
     for NodeCleanupInfo {
         master_fd,
         process_id,
@@ -115,7 +119,7 @@ pub async fn cleanup(
         if let Some(anvil) = anvil_process {
             info!("Cleaning up anvil fakechain...\r");
             clean_process_by_pid(*anvil);
-            info!("Cleaned up anvil fakechain.");
+            info!("Done cleaning up anvil fakechain.\r");
         }
 
         other_processes
@@ -133,7 +137,6 @@ pub async fn cleanup(
         }
         info!("Done cleaning up {:?}.\r", home);
     }
-    let _ = send_to_kill.send(should_print_std.is_some_and(|b| b));
 }
 
 #[instrument(level = "trace", skip_all)]
@@ -161,7 +164,7 @@ pub async fn drain_print_runtime(
                 if should_print_std {
                     let stdout = remove_repeated_newlines(&stdout_buffer);
                     let stderr = remove_repeated_newlines(&stderr_buffer);
-                    println!("stdout:\n{}\nstderr:\n{}", stdout, stderr);
+                    info!("stdout:\n{}\nstderr:\n{}", stdout, stderr);
                 }
                 return;
             }

--- a/src/run_tests/mod.rs
+++ b/src/run_tests/mod.rs
@@ -2,12 +2,14 @@ use std::process::Command;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use color_eyre::{eyre::eyre, Result};
+use color_eyre::{eyre::{eyre, WrapErr}, Result};
 use dirs::home_dir;
 use fs_err as fs;
 use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration};
 use tracing::{debug, info, instrument};
+
+use kinode_process_lib::kernel_types::PackageManifestEntry;
 
 use crate::boot_fake_node::{compile_runtime, get_runtime_binary, run_runtime};
 use crate::build;
@@ -76,13 +78,10 @@ impl Config {
             }
         };
         for test in self.tests.iter_mut() {
-            test.test_packages = test
-                .test_packages
+            test.test_package_paths = test
+                .test_package_paths
                 .iter()
-                .map(|tp| TestPackage {
-                    path: expand_home_path(&tp.path).unwrap_or_else(|| tp.path.clone()),
-                    grant_capabilities: tp.grant_capabilities.clone(),
-                })
+                .map(|p| expand_home_path(&p).unwrap_or_else(|| p.clone()))
                 .collect();
             for node in test.nodes.iter_mut() {
                 node.home = expand_home_path(&node.home).unwrap_or_else(|| node.home.clone());
@@ -184,36 +183,38 @@ async fn load_process(path: &Path, drive: &str, port: &u16) -> Result<()> {
 }
 
 #[instrument(level = "trace", skip_all)]
-async fn load_tests(test_packages: &Vec<TestPackage>, port: u16) -> Result<()> {
-    info!("Loading tests...");
-
-    for TestPackage { ref path, .. } in test_packages {
-        load_process(path, "tests", &port).await?;
-    }
-
-    let mut grant_caps = std::collections::HashMap::new();
-    for TestPackage {
-        ref path,
-        ref grant_capabilities,
-    } in test_packages
-    {
-        grant_caps.insert(
-            path.file_name().map(|f| f.to_str()).unwrap(),
-            grant_capabilities,
+async fn load_caps(test_package_paths: &Vec<PathBuf>, port: u16) -> Result<()> {
+    let mut caps = std::collections::HashMap::new();
+    for test_package_path in test_package_paths {
+        let manifest_path = test_package_path.join("pkg").join("manifest.json");
+        let manifest: Vec<PackageManifestEntry> =
+            serde_json::from_reader(fs::File::open(manifest_path)
+                .wrap_err_with(|| "Missing required manifest.json file. See discussion at https://book.kinode.org/my_first_app/chapter_1.html?highlight=manifest.json#pkgmanifestjson")?
+            )?;
+        if manifest.len() != 1 {
+            return Err(eyre!(""));
+        }
+        let manifest = manifest.iter().next().unwrap();
+        caps.insert(
+            test_package_path.file_name().map(|f| f.to_str()).unwrap(),
+            serde_json::json!({
+                "request_capabilities": manifest.request_capabilities,
+                "grant_capabilities": manifest.grant_capabilities,
+            })
         );
     }
-    let grant_caps = serde_json::to_vec(&grant_caps)?;
+    let caps = serde_json::to_vec(&caps)?;
 
     let request = inject_message::make_message(
         "vfs:distro:sys",
         Some(15),
         &serde_json::to_string(&serde_json::json!({
-            "path": format!("/tester:sys/tests/grant_capabilities.json"),
+            "path": format!("/tester:sys/tests/capabilities.json"),
             "action": "Write",
         }))
         .unwrap(),
         None,
-        Some(&grant_caps),
+        Some(&caps),
         None,
     )?;
 
@@ -224,13 +225,27 @@ async fn load_tests(test_packages: &Vec<TestPackage>, port: u16) -> Result<()> {
         Err(e) => return Err(eyre!("Failed to load tests capabilities: {}", e)),
     }
 
+    Ok(())
+}
+
+
+#[instrument(level = "trace", skip_all)]
+async fn load_tests(test_package_paths: &Vec<PathBuf>, port: u16) -> Result<()> {
+    info!("Loading tests...");
+
+    for test_package_path in test_package_paths {
+        load_process(&test_package_path, "tests", &port).await?;
+    }
+
+    load_caps(test_package_paths, port).await?;
+
     info!("Done loading tests.");
     Ok(())
 }
 
 #[instrument(level = "trace", skip_all)]
 async fn run_tests(
-    test_packages: &Vec<TestPackage>,
+    test_package_paths: &Vec<PathBuf>,
     mut ports: Vec<u16>,
     node_names: Vec<String>,
     test_timeout: u64,
@@ -245,9 +260,9 @@ async fn run_tests(
             &serde_json::to_string(&serde_json::json!({
                 "Run": {
                     "input_node_names": node_names,
-                    "test_names": test_packages
+                    "test_names": test_package_paths
                         .iter()
-                        .map(|tp| tp.path.to_str().unwrap())
+                        .map(|p| p.to_str().unwrap())
                         .collect::<Vec<&str>>(),
                     "test_timeout": test_timeout,
                 }
@@ -273,9 +288,9 @@ async fn run_tests(
         &serde_json::to_string(&serde_json::json!({
             "Run": {
                 "input_node_names": node_names,
-                "test_names": test_packages
+                "test_names": test_package_paths
                     .iter()
-                    .map(|tp| tp.path.to_str().unwrap())
+                    .map(|p| p.to_str().unwrap())
                     .collect::<Vec<&str>>(),
                 "test_timeout": test_timeout,
             }
@@ -330,14 +345,11 @@ async fn handle_test(
             }
         })
         .collect();
-    let test_packages: Vec<TestPackage> = test
-        .test_packages
+    let test_package_paths: Vec<PathBuf> = test
+        .test_package_paths
         .iter()
         .cloned()
-        .map(|tp| TestPackage {
-            path: test_dir_path.join(tp.path).canonicalize().unwrap(),
-            grant_capabilities: tp.grant_capabilities,
-        })
+        .map(|p| test_dir_path.join(p).canonicalize().unwrap())
         .collect();
     for setup_package in &setup_packages {
         build::execute(
@@ -351,8 +363,8 @@ async fn handle_test(
             false,
         ).await?; // TODO
     }
-    for TestPackage { ref path, .. } in &test_packages {
-        let path = test_dir_path.join(path).canonicalize()?;
+    for test_package_path in &test_package_paths {
+        let path = test_dir_path.join(&test_package_path).canonicalize()?;
         build::execute(
             &path,
             false,
@@ -495,12 +507,12 @@ async fn handle_test(
         load_setups(&setup_packages, node.port.clone()).await?;
     }
 
-    load_tests(&test_packages, master_node_port.unwrap().clone()).await?;
+    load_tests(&test_package_paths, master_node_port.unwrap().clone()).await?;
 
     let ports = test.nodes.iter().map(|n| n.port).collect();
 
     let tests_result = run_tests(
-        &test.test_packages,
+        &test.test_package_paths,
         ports,
         make_node_names(test.nodes)?,
         test.timeout_secs,

--- a/src/run_tests/types.rs
+++ b/src/run_tests/types.rs
@@ -1,6 +1,5 @@
 use std::os::unix::io::OwnedFd;
 use std::path::PathBuf;
-//use std::process::Child;
 use std::sync::Arc;
 
 use tokio::process::Child;
@@ -26,7 +25,8 @@ pub enum Runtime {
 pub struct Test {
     pub setup_packages: Vec<SetupPackage>,
     pub setup_scripts: Vec<Script>,
-    pub test_packages: Vec<TestPackage>,
+    pub test_package_paths: Vec<PathBuf>,
+    //pub test_packages: Vec<TestPackage>,
     pub test_scripts: Vec<Script>,
     pub timeout_secs: u64,
     pub fakechain_router: u16,
@@ -37,12 +37,6 @@ pub struct Test {
 pub struct SetupPackage {
     pub path: PathBuf,
     pub run: bool,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TestPackage {
-    pub path: PathBuf,
-    pub grant_capabilities: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/run_tests/types.rs
+++ b/src/run_tests/types.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 pub struct Config {
     pub runtime: Runtime,
     pub runtime_build_release: bool,
+    pub persist_home: bool,
     pub tests: Vec<Test>,
 }
 
@@ -23,13 +24,19 @@ pub enum Runtime {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Test {
-    pub setup_package_paths: Vec<PathBuf>,
-    pub test_packages: Vec<TestPackage>,
+    pub setup_packages: Vec<SetupPackage>,
     pub setup_scripts: Vec<Script>,
+    pub test_packages: Vec<TestPackage>,
     pub test_scripts: Vec<Script>,
     pub timeout_secs: u64,
     pub fakechain_router: u16,
     pub nodes: Vec<Node>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetupPackage {
+    pub path: PathBuf,
+    pub run: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/run_tests/types.rs
+++ b/src/run_tests/types.rs
@@ -25,6 +25,8 @@ pub enum Runtime {
 pub struct Test {
     pub setup_package_paths: Vec<PathBuf>,
     pub test_packages: Vec<TestPackage>,
+    pub setup_scripts: Vec<Script>,
+    pub test_scripts: Vec<Script>,
     pub timeout_secs: u64,
     pub fakechain_router: u16,
     pub nodes: Vec<Node>,
@@ -34,6 +36,12 @@ pub struct Test {
 pub struct TestPackage {
     pub path: PathBuf,
     pub grant_capabilities: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Script {
+    pub path: PathBuf,
+    pub args: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -60,6 +68,7 @@ pub struct NodeCleanupInfo {
     pub process_id: i32,
     pub home: PathBuf,
     pub anvil_process: Option<i32>,
+    pub other_processes: Vec<i32>,
 }
 
 pub struct CleanupContext {


### PR DESCRIPTION
## Problem

Tests must be able to run scripts external to Kinode if we hope to test external-facing functionality.

## Solution

Add the ability to run scripts.

## Docs Update

https://github.com/kinode-dao/kinode-book/pull/227/commits/caecd374b58a3da3c691d602f1509c959af7c2c7


## Notes

None