### PR TITLE
build: add `--local-dependency` flag

### DIFF
--- a/src/build_start_package/mod.rs
+++ b/src/build_start_package/mod.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use color_eyre::Result;
 use tracing::instrument;
@@ -15,7 +15,9 @@ pub async fn execute(
     skip_deps_check: bool,
     features: &str,
     download_from: Option<&str>,
-    default_world: Option<String>,
+    default_world: Option<&str>,
+    local_dependencies: Vec<PathBuf>,
+    force: bool,
     verbose: bool,
 ) -> Result<()> {
     build::execute(
@@ -27,6 +29,8 @@ pub async fn execute(
         Some(url.into()),
         download_from,
         default_world,
+        local_dependencies,
+        force,
         verbose,
     )
     .await?;

--- a/src/run_tests/mod.rs
+++ b/src/run_tests/mod.rs
@@ -271,6 +271,12 @@ async fn build_packages(
     persist_home: &bool,
     runtime_path: &Path,
 ) -> Result<(Vec<SetupPackage>, Vec<PathBuf>)> {
+    let dependency_package_paths: Vec<PathBuf> = test
+        .dependency_package_paths
+        .iter()
+        .cloned()
+        .map(|p| test_dir_path.join(p).canonicalize().unwrap())
+        .collect();
     let setup_packages: Vec<SetupPackage> = test
         .setup_packages
         .iter()
@@ -344,6 +350,8 @@ async fn build_packages(
             Some(url.clone()),
             None,
             None,
+            dependency_package_paths.clone(),
+            false,
             false,
         ).await?;
         start_package::execute(&path, &url).await?;
@@ -359,6 +367,8 @@ async fn build_packages(
             Some(url.clone()),
             None,
             None,
+            dependency_package_paths.clone(),
+            false,
             false,
         ).await?;
     }
@@ -372,6 +382,8 @@ async fn build_packages(
             Some(url.clone()),
             None,
             None,
+            dependency_package_paths.clone(),
+            false,
             false,
         ).await?;
     }


### PR DESCRIPTION
## Problem

If a dependency is unpublished, can't build something depending on it.

## Solution

Add a flag, `--local-dependency`, to `kit build`. It can be passed multiple times. It is a path to a package. These dependencies will be used to satisfy  the dependencies of the package being built.

## Example usage

In the [kinode-book code, the remote_file_storage example](https://github.com/kinode-dao/kinode-book/tree/main/src/code/remote_file_storage):

```
kit b client -l server
```

## Docs Update

https://github.com/kinode-dao/kinode-book/pull/233/commits/38936df029b55a6d43d36771234a345a371f4cba

## Notes

[Brainstorming document](https://gist.github.com/nick1udwig/81b3e01a8eb2ba8e0bf327e9f1168821)