### PR TITLE
kit publish cont'd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,8 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "async-trait",
+ "elliptic-curve",
+ "eth-keystore",
  "k256",
  "rand",
  "thiserror",
@@ -1252,6 +1254,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1434,6 +1445,28 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "eth-keystore"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
+dependencies = [
+ "aes",
+ "ctr",
+ "digest 0.10.7",
+ "hex",
+ "hmac",
+ "pbkdf2",
+ "rand",
+ "scrypt",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sha3",
+ "thiserror",
+ "uuid",
 ]
 
 [[package]]
@@ -2197,6 +2230,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "keccak-asm"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2249,6 +2291,7 @@ dependencies = [
  "regex",
  "reqwest 0.11.27",
  "rmp-serde",
+ "rpassword",
  "semver 1.0.23",
  "serde",
  "serde_json",
@@ -3132,6 +3175,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ruint"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3279,6 +3343,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3301,6 +3374,18 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
+dependencies = [
+ "hmac",
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
 
 [[package]]
 name = "sec1"
@@ -3441,6 +3526,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
 ]
 
 [[package]]
@@ -4158,6 +4253,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
+ "serde",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ alloy = { version = "0.1.3", features = [
     "rpc-types",
     "rpc-types-eth",
     "signers",
+    "signer-keystore",
     "signer-local",
 ] }
 alloy-sol-macro = "0.7.6"
@@ -38,6 +39,7 @@ nix = { version = "0.27", features = ["process", "signal", "term"] }
 regex = "1"
 reqwest = { version = "0.11", features = ["json"] }
 rmp-serde = "1.1.2"
+rpassword = "7"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/boot_fake_node/mod.rs
+++ b/src/boot_fake_node/mod.rs
@@ -390,10 +390,7 @@ pub async fn execute(
                     .join(if release { "release" } else { "debug" })
                     .join("kinode")
             } else {
-                return Err(eyre!(
-                    "--runtime-path {:?} must be a directory (the repo).",
-                    runtime_path,
-                ));
+                runtime_path
             }
         },
     };

--- a/src/publish/mod.rs
+++ b/src/publish/mod.rs
@@ -18,48 +18,48 @@ use alloy_sol_macro::sol;
 use alloy_sol_types::SolCall;
 
 sol! {
-        function mint (
-            address who,
-            bytes calldata label,
-            bytes calldata initialization,
-            bytes calldata erc721Data,
-            address implementation
-        ) external returns (
-            address tba
-        );
+    function mint (
+        address who,
+        bytes calldata label,
+        bytes calldata initialization,
+        bytes calldata erc721Data,
+        address implementation
+    ) external returns (
+        address tba
+    );
 
-        function get (
-            bytes32 node
-        ) external view returns (
-            address tba,
-            address owner,
-            bytes data,
-        );
+    function get (
+        bytes32 node
+    ) external view returns (
+        address tba,
+        address owner,
+        bytes data,
+    );
 
-        function note (
-            bytes calldata note,
-            bytes calldata data
-        ) external returns (
-            bytes32 notenode
-        );
+    function note (
+        bytes calldata note,
+        bytes calldata data
+    ) external returns (
+        bytes32 notenode
+    );
 
-        // tba account
-        function execute(
-            address to,
-            uint256 value,
-            bytes calldata data,
-            uint8 operation
-        ) external payable returns (bytes memory returnData);
+    // tba account
+    function execute(
+        address to,
+        uint256 value,
+        bytes calldata data,
+        uint8 operation
+    ) external payable returns (bytes memory returnData);
 
 
-        struct Call {
-            address target;
-            bytes callData;
-        }
+    struct Call {
+        address target;
+        bytes callData;
+    }
 
-        function aggregate(
-            Call[] calldata calls
-        ) external payable returns (uint256 blockNumber, bytes[] memory returnData);
+    function aggregate(
+        Call[] calldata calls
+    ) external payable returns (uint256 blockNumber, bytes[] memory returnData);
 }
 
 const KIMAP_ADDRESS: &str = "0x0165878A594ca255338adfa4d48449f69242Eb8F";

--- a/src/publish/mod.rs
+++ b/src/publish/mod.rs
@@ -1,6 +1,3 @@
-use color_eyre::eyre::{self, Result};
-use reqwest::Client;
-use serde_json::Value;
 use std::fs;
 use std::path::Path;
 use std::str::FromStr;
@@ -16,6 +13,9 @@ use alloy::{
 };
 use alloy_sol_macro::sol;
 use alloy_sol_types::SolCall;
+use color_eyre::eyre::{self, Result};
+use reqwest::Client;
+use serde_json::Value;
 
 sol! {
     function mint (


### PR DESCRIPTION
## Problem

We want devs to be able to publish packages from `kit`.

## Solution

Add `kit publish`.

## Docs Update

TODO

Brief usage guide:
```
# make a keystore
## copy-paste in private key into interactive prompt:
## 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
## (gotten via `anvil --balance 5 --state kit/src/chain/kinostate.json`)
cast w import -i anvil-1

# start a 0.9.0 fake node
kit f -r ~/git/kinode

# put package onto node; here I use https://github.com/nick1udwig/chat
git clone https://github.com/nick1udwig/chat
cd chat
kit bs

# publish package
## you will be prompted for the keystore password that you set when calling `cast` above
kit p -u https://raw.githubusercontent.com/nick1udwig/chat/50d06b9bea3bce7e3c418ccb40a85a5c785dab9b/metadata.json -k ~/.foundry/keystores/anvil-1
```

## Notes

~~WIP~~