### PR TITLE
add 'blank' template for kit new (rust-only)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -187,7 +187,8 @@ async fn execute(
                 Some(f) => f.clone(),
                 None => "".into(),
             };
-            let url = matches.get_one::<u16>("NODE_PORT")
+            let url = matches
+                .get_one::<u16>("NODE_PORT")
                 .map(|p| format!("http://localhost:{p}"));
             let download_from = matches
                 .get_one::<String>("NODE")
@@ -226,16 +227,12 @@ async fn execute(
         Some(("build-start-package", matches)) => {
             let package_dir = PathBuf::from(matches.get_one::<String>("DIR").unwrap());
             let no_ui = matches.get_one::<bool>("NO_UI").unwrap();
-            let ui_only = matches
-                .get_one::<bool>("UI_ONLY")
-                .unwrap_or(&false);
+            let ui_only = matches.get_one::<bool>("UI_ONLY").unwrap_or(&false);
             let url = format!(
                 "http://localhost:{}",
                 matches.get_one::<u16>("NODE_PORT").unwrap(),
             );
-            let skip_deps_check = matches
-                .get_one::<bool>("SKIP_DEPS_CHECK")
-                .unwrap();
+            let skip_deps_check = matches.get_one::<bool>("SKIP_DEPS_CHECK").unwrap();
             let features = match matches.get_one::<String>("FEATURES") {
                 Some(f) => f.clone(),
                 None => "".into(),
@@ -281,12 +278,8 @@ async fn execute(
         Some(("connect", matches)) => {
             let local_port = matches.get_one::<u16>("LOCAL_PORT").unwrap();
             let disconnect = matches.get_one::<bool>("IS_DISCONNECT").unwrap();
-            let host = matches
-                .get_one::<String>("HOST")
-                .map(|s| s.as_ref());
-            let host_port = matches
-                .get_one::<u16>("HOST_PORT")
-                .map(|hp| hp.clone());
+            let host = matches.get_one::<String>("HOST").map(|s| s.as_ref());
+            let host_port = matches.get_one::<u16>("HOST_PORT").map(|hp| hp.clone());
             connect::execute(*local_port, *disconnect, host, host_port)
         }
         Some(("dev-ui", matches)) => {
@@ -344,8 +337,7 @@ async fn execute(
             let publisher = matches
                 .get_one::<String>("PUBLISHER")
                 .and_then(|s: &String| Some(s.as_str()));
-            let package_dir =
-                PathBuf::from(matches.get_one::<String>("DIR").unwrap());
+            let package_dir = PathBuf::from(matches.get_one::<String>("DIR").unwrap());
             let url = format!(
                 "http://localhost:{}",
                 matches.get_one::<u16>("NODE_PORT").unwrap(),
@@ -375,8 +367,7 @@ async fn execute(
             setup::execute(*verbose)
         }
         Some(("start-package", matches)) => {
-            let package_dir =
-                PathBuf::from(matches.get_one::<String>("DIR").unwrap());
+            let package_dir = PathBuf::from(matches.get_one::<String>("DIR").unwrap());
             let url = format!(
                 "http://localhost:{}",
                 matches.get_one::<u16>("NODE_PORT").unwrap(),
@@ -910,7 +901,7 @@ async fn make_app(current_dir: &std::ffi::OsString) -> Result<Command> {
                 .short('t')
                 .long("template")
                 .help("Template to create")
-                .value_parser(["chat", "echo", "fibonacci", "file_transfer"])
+                .value_parser(["blank", "chat", "echo", "fibonacci", "file_transfer"])
                 .default_value("chat")
             )
             .arg(Arg::new("UI")

--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -18,6 +18,7 @@ pub enum Language {
 
 #[derive(Clone)]
 pub enum Template {
+    Blank,
     Chat,
     Echo,
     Fibonacci,
@@ -38,6 +39,7 @@ impl Language {
 impl Template {
     fn to_string(&self) -> String {
         match self {
+            Template::Blank => "blank",
             Template::Chat => "chat",
             Template::Echo => "echo",
             Template::Fibonacci => "fibonacci",
@@ -61,11 +63,12 @@ impl From<&String> for Language {
 impl From<&String> for Template {
     fn from(s: &String) -> Self {
         match s.as_str() {
+            "blank" => Template::Blank,
             "chat" => Template::Chat,
             "echo" => Template::Echo,
             "fibonacci" => Template::Fibonacci,
             "file_transfer" => Template::FileTransfer,
-            _ => panic!("kit: template must be 'chat', 'echo', or 'fibonacci'; not '{s}'"),
+            _ => panic!("kit: template must be 'blank', 'chat', 'echo', or 'fibonacci'; not '{s}'"),
         }
     }
 }

--- a/src/new/templates/rust/no-ui/blank/.gitignore
+++ b/src/new/templates/rust/no-ui/blank/.gitignore
@@ -1,0 +1,8 @@
+*/target/
+/target
+pkg/*.wasm
+*.swp
+*.swo
+*/wasi_snapshot_preview1.wasm
+*/wit/
+*/process_env

--- a/src/new/templates/rust/no-ui/blank/Cargo.toml_
+++ b/src/new/templates/rust/no-ui/blank/Cargo.toml_
@@ -1,0 +1,10 @@
+[workspace]
+resolver = "2"
+members = [
+    "{package_name}",
+]
+
+[profile.release]
+panic = "abort"
+opt-level = "s"
+lto = true

--- a/src/new/templates/rust/no-ui/blank/metadata.json
+++ b/src/new/templates/rust/no-ui/blank/metadata.json
@@ -1,0 +1,18 @@
+{
+    "name": "{package_name}",
+    "description": "",
+    "image": "",
+    "properties": {
+        "package_name": "{package_name}",
+        "current_version": "0.1.0",
+        "publisher": "{publisher}",
+        "mirrors": [],
+        "code_hashes": {
+            "0.1.0": ""
+        },
+        "wit_version": 0,
+        "dependencies": []
+    },
+    "external_url": "",
+    "animation_url": ""
+}

--- a/src/new/templates/rust/no-ui/blank/pkg/manifest.json
+++ b/src/new/templates/rust/no-ui/blank/pkg/manifest.json
@@ -1,0 +1,11 @@
+[
+    {
+        "process_name": "{package_name}",
+        "process_wasm_path": "/{package_name}.wasm",
+        "on_exit": "Restart",
+        "request_networking": false,
+        "request_capabilities": [],
+        "grant_capabilities": [],
+        "public": false
+    }
+]

--- a/src/new/templates/rust/no-ui/blank/{package_name}/Cargo.toml_
+++ b/src/new/templates/rust/no-ui/blank/{package_name}/Cargo.toml_
@@ -1,0 +1,16 @@
+[package]
+name = "{package_name}"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+kinode_process_lib = "0.8.5"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+wit-bindgen = "0.24.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[package.metadata.component]
+package = "kinode:process"

--- a/src/new/templates/rust/no-ui/blank/{package_name}/src/lib.rs
+++ b/src/new/templates/rust/no-ui/blank/{package_name}/src/lib.rs
@@ -1,0 +1,16 @@
+use kinode_process_lib::{await_message, call_init, Address};
+
+wit_bindgen::generate!({
+    path: "target/wit",
+    world: "process-v0",
+});
+
+call_init!(init);
+fn init(_our: Address) {
+    loop {
+        match await_message() {
+            Err(send_error) => println!("got SendError: {send_error}"),
+            Ok(message) => println!("got Message: {message:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## Problem

I really want a blank template for creating new packages

## Solution

Add a template keyed 'blank' which contains the absolute minimum Kinode package for Rust.

## Docs Update

N/A

## Notes

Please double-check I caught all the spots where it's necessary to add this as a new template!

I would also note that it's important to keep the version of kinode_process_lib being used by templates as recent as possible, though I'm not sure of a good way to do that
