### PR TITLE
start: add version_hash to InstallRequest

### DIFF
--- a/src/start_package/mod.rs
+++ b/src/start_package/mod.rs
@@ -9,7 +9,7 @@ use tracing::{info, instrument};
 use walkdir::WalkDir;
 use zip::write::FileOptions;
 
-use kinode_process_lib::kernel_types::{Erc721Metadata, PackageManifestEntry};
+use kinode_process_lib::kernel_types::PackageManifestEntry;
 
 use crate::{build::read_metadata, inject_message, KIT_LOG_PATH_DEFAULT};
 
@@ -18,30 +18,11 @@ fn new_package(
     node: Option<&str>,
     package_name: &str,
     publisher_node: &str,
-    metadata: &Erc721Metadata,
     bytes_path: &str,
 ) -> Result<serde_json::Value> {
     let message = json!({
         "NewPackage": {
             "package_id": {"package_name": package_name, "publisher_node": publisher_node},
-            "metadata": {
-                "name": metadata.name,
-                "description": metadata.description,
-                "image": metadata.image,
-                "external_url": metadata.external_url,
-                "animation_url": metadata.animation_url,
-                "properties": {
-                    "package_name": metadata.properties.package_name,
-                    "publisher": metadata.properties.publisher,
-                    "current_version": metadata.properties.current_version,
-                    "mirrors": metadata.properties.mirrors,
-                    "code_hashes": metadata.properties.code_hashes.clone().into_iter().collect::<Vec<(String, String)>>(),
-                    "license": metadata.properties.license,
-                    "screenshots": metadata.properties.screenshots,
-                    "wit_version": metadata.properties.wit_version,
-                    "dependencies": metadata.properties.dependencies,
-                },
-            },
             "mirror": true
         }
     });
@@ -140,7 +121,6 @@ pub async fn execute(package_dir: &Path, url: &str) -> Result<()> {
         None,
         package_name,
         publisher,
-        &metadata,
         zip_filename.to_str().unwrap(),
     )?;
     let response = inject_message::send_request(url, new_pkg_request).await?;
@@ -168,7 +148,29 @@ pub async fn execute(package_dir: &Path, url: &str) -> Result<()> {
     // Install package
     let body = json!({
         "Install": {
-            "package_id": {"package_name": package_name, "publisher_node": publisher, "version": hash_string},
+            "package_id": {
+                "package_name": package_name,
+                "publisher_node": publisher,
+            },
+            "version_hash": hash_string,
+            "metadata": {
+                "name": metadata.name,
+                "description": metadata.description,
+                "image": metadata.image,
+                "external_url": metadata.external_url,
+                "animation_url": metadata.animation_url,
+                "properties": {
+                    "package_name": metadata.properties.package_name,
+                    "publisher": metadata.properties.publisher,
+                    "current_version": metadata.properties.current_version,
+                    "mirrors": metadata.properties.mirrors,
+                    "code_hashes": metadata.properties.code_hashes.clone().into_iter().collect::<Vec<(String, String)>>(),
+                    "license": metadata.properties.license,
+                    "screenshots": metadata.properties.screenshots,
+                    "wit_version": metadata.properties.wit_version,
+                    "dependencies": metadata.properties.dependencies,
+                },
+            },
         }
     });
     let install_request = inject_message::make_message(


### PR DESCRIPTION
## Problem & Solution

The new [app_store](https://github.com/kinode-dao/kinode/pull/472) can handle several versions of a package in `/downloads/{package_id}/{hash}.zip`. When starting, we keep the same NewPackageRequest, but app_store now zips it, puts it in the downloads folder.
Need to specify a version_hash to install (which will be the same we added with NewPackageRequest).

## Docs Update

Shouldn't be any change to user behaviour, but pending relevant docs if available.

