### PR TITLE
chain: automatic blocktime

### DIFF
--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -57,7 +57,7 @@ pub async fn start_chain(
         .arg("--port")
         .arg(port.to_string())
         .arg("--block-time")
-        .arg("3")
+        .arg("1")
         .arg("--load-state")
         .arg(&state_path)
         .current_dir(KIT_CACHE)

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -56,6 +56,8 @@ pub async fn start_chain(
     let mut child = Command::new("anvil")
         .arg("--port")
         .arg(port.to_string())
+        .arg("--block-time")
+        .arg("3")
         .arg("--load-state")
         .arg(&state_path)
         .current_dir(KIT_CACHE)


### PR DESCRIPTION
## Problem

The new kns_indexer has 2 subscriptions open, 1 to mints and 1 to notes. If a note event precedes it's parents mint event, it stores pending_notes and uses a get_block timer to resolve them later.

see https://github.com/kinode-dao/kinode/pull/505

## Solution

Set an automatic block_mine (even if empty) to 1s. 

## Notes

See if this ramps up memory usage, or otherwise runs away. 
Also, fakenodes now wait until they've gotten a receipt back from the tx before they boot. 
This takes longer with the default block_mine, as anvil won't immediately mine a block upon a transaction like before. 

