### PR TITLE
fix `kit r` & `kit b` when upgrading api

### DIFF
--- a/src/boot_fake_node/mod.rs
+++ b/src/boot_fake_node/mod.rs
@@ -311,7 +311,10 @@ pub async fn find_releases_with_asset_if_online(
 fn get_local_versions_with_prefix(prefix: &str) -> Result<Vec<String>> {
     let mut versions = Vec::new();
 
-    for entry in fs::read_dir(Path::new(prefix).parent().unwrap())? {
+    let path = Path::new(prefix)
+        .parent()
+        .ok_or_else(|| eyre!("couldnt find directory with local runtimes"))?;
+    for entry in fs::read_dir(&path)? {
         let entry = entry?;
         let path = entry.path();
         if let Some(str_path) = path.to_str() {

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -705,6 +705,9 @@ async fn build_wit_dir(
     wit_version: Option<u32>,
 ) -> Result<()> {
     let wit_dir = process_dir.join("target").join("wit");
+    if wit_dir.exists() {
+        fs::remove_dir_all(&wit_dir)?;
+    }
     let wit_url = match wit_version {
         None => KINODE_WIT_0_7_0_URL,
         Some(0) | _ => KINODE_WIT_0_8_0_URL,
@@ -712,13 +715,6 @@ async fn build_wit_dir(
     download_file(wit_url, &wit_dir.join("kinode.wit")).await?;
     for (file_name, contents) in apis {
         let destination = wit_dir.join(file_name);
-        if destination.exists() {
-            // check if contents have not changed -> no-op
-            let old_contents = fs::read(&destination)?;
-            if &old_contents == contents {
-                continue;
-            }
-        }
         fs::write(&destination, contents)?;
     }
     Ok(())

--- a/src/start_package/mod.rs
+++ b/src/start_package/mod.rs
@@ -37,16 +37,14 @@ fn new_package(
 #[instrument(level = "trace", skip_all)]
 fn install(
     node: Option<&str>,
-    package_name: &str,
-    publisher_node: &str,
     hash_string: &str,
     metadata: &Erc721Metadata,
 ) -> Result<serde_json::Value> {
     let body = json!({
         "Install": {
             "package_id": {
-                "package_name": package_name,
-                "publisher_node": publisher_node,
+                "package_name": metadata.properties.package_name,
+                "publisher_node": metadata.properties.publisher,
             },
             "version_hash": hash_string,
             "metadata": {
@@ -150,8 +148,6 @@ pub async fn execute(package_dir: &Path, url: &str) -> Result<()> {
 
     let install_request = install(
         None,
-        package_name,
-        publisher,
         &hash_string,
         &metadata,
     )?;


### PR DESCRIPTION
## Problem

1. `kit r` doesn't work properly.
2. When upgrading wit API version, things break because old API is still in build dir.

## Solution

1. Fix it
2. Remove build dir.

## Docs Update

None

## Notes

None