### PR TITLE
build: provide useful errors when process_lib versions mismatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,6 +1013,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.23",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cc"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,6 +2106,7 @@ dependencies = [
  "alloy-sol-types",
  "anyhow",
  "base64 0.21.7",
+ "cargo_metadata",
  "clap",
  "color-eyre",
  "dirs",
@@ -3220,6 +3253,9 @@ name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "semver-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ alloy = { version = "0.1.3", features = [
 alloy-sol-macro = "0.7.6"
 alloy-sol-types = "0.7.6"
 base64 = "0.21"
+cargo_metadata = "0.18"
 clap = { version = "4.4", features = ["cargo", "string"] }
 color-eyre = { version = "0.6", features = ["capture-spantrace"] }
 dirs = "5.0"


### PR DESCRIPTION
## Problem

Resolves #220

## Solution

Check process_lib versions and, if they don't match, error out with a helpful error message.

## Docs Update

None

## Notes

Error looks like:
```
$ kit b --force
ERROR src/main.rs:1195: 
   0: Found different versions of kinode_process_lib in different crates:
      ^0.8.5	["my_lib"]
      ^0.9.0	["foo", "bar", "baz", "lol", "rofl"]

Location:
   src/build/mod.rs:393

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ SPANTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

   0: kit::build::check_process_lib_version
      at src/build/mod.rs:380
   1: kit::build::execute
      at src/build/mod.rs:1275

Suggestion: Set all kinode_process_lib versions to be the same to avoid hard-to-debug errors.

```