### PR TITLE
run-tests: generalize scripts

### DIFF
--- a/src/run_tests/types.rs
+++ b/src/run_tests/types.rs
@@ -25,9 +25,9 @@ pub enum Runtime {
 pub struct Test {
     pub dependency_package_paths: Vec<PathBuf>,
     pub setup_packages: Vec<SetupPackage>,
-    pub setup_scripts: Vec<Script>,
+    pub setup_scripts: Vec<String>,
     pub test_package_paths: Vec<PathBuf>,
-    pub test_scripts: Vec<Script>,
+    pub test_scripts: Vec<String>,
     pub timeout_secs: u64,
     pub fakechain_router: u16,
     pub nodes: Vec<Node>,
@@ -37,12 +37,6 @@ pub struct Test {
 pub struct SetupPackage {
     pub path: PathBuf,
     pub run: bool,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Script {
-    pub path: PathBuf,
-    pub args: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -160,8 +160,13 @@ pub fn get_newest_valid_node_version(
         if fields.len() == 1 {
             versions.push(fields[0].to_string());
         } else if fields.len() == 2 {
-            assert_eq!("->", fields[0]);
-            versions.push(fields[1].to_string());
+            if "->" == fields[0] {
+                versions.push(fields[1].to_string());
+            } else if fields[1] == "*" {
+                versions.push(fields[0].to_string());
+            } else {
+                warn!("unexpected line {line} in `nvm ls --no-alias`; skipping:\n{nvm_ls}");
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

Instead of inputting scripts with `path = ..., args = ...`, 

## Solution

Just accept a `bash` line & canonicalize all paths therein

## Docs Update

None

## Notes

None