### PR TITLE
boot-fake-node: use linux aarch64

### DIFF
--- a/src/boot_fake_node/mod.rs
+++ b/src/boot_fake_node/mod.rs
@@ -133,11 +133,12 @@ pub fn get_platform_runtime_name(is_simulation_mode: bool) -> Result<String> {
     // TODO: update when have binaries
     let zip_name_midfix = match (os_name, architecture_name) {
         ("Linux", "x86_64") => "x86_64-unknown-linux-gnu",
+        ("Linux", "aarch64") => "aarch64-unknown-linux-gnu",
         ("Darwin", "arm64") => "arm64-apple-darwin",
         ("Darwin", "x86_64") => "x86_64-apple-darwin",
         _ => {
             return Err(eyre!(
-                "OS/Architecture {}/{} not amongst pre-built [Linux/x86_64, Apple/arm64, Apple/x86_64].",
+                "OS/Architecture {}/{} not amongst pre-built [Linux/x86_64, Linux/aarch64, Apple/arm64, Apple/x86_64].",
                 os_name,
                 architecture_name,
             ).with_suggestion(|| "Use the `--runtime-path` flag to build a local copy of the https://github.com/kinode-dao/kinode repo")


### PR DESCRIPTION
## Problem

We publish aarch64 linux binaries but don't allow them in `kit`.

## Solution

Allow them in `kit`.

## Docs Update

None

## Notes

None