### PR TITLE
build: fix up to date detection

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -30,8 +30,8 @@ jobs:
           rustup update
           cargo install wasm-tools
           rustup install nightly
-          rustup target add wasm32-wasi
-          rustup target add wasm32-wasi --toolchain nightly
+          rustup target add wasm32-wasip1
+          rustup target add wasm32-wasip1 --toolchain nightly
           cargo install cargo-wasi
       #- name: Get latest release from foundry-rs/foundry
       #  id: get-latest-foundry-release


### PR DESCRIPTION
## Problem

`kit` does not realize it needs to re-build a package when a local dep is updated.

## Solution

Check local deps for modification & build if they are modified.

## Docs Update

None

## Notes

None