### PR TITLE
boot-fake-node: fix offline cache-based-fallback

### DIFF
--- a/src/boot_fake_node/mod.rs
+++ b/src/boot_fake_node/mod.rs
@@ -312,9 +312,7 @@ pub async fn find_releases_with_asset_if_online(
 fn get_local_versions_with_prefix(prefix: &str) -> Result<Vec<String>> {
     let mut versions = Vec::new();
 
-    let path = Path::new(prefix)
-        .parent()
-        .ok_or_else(|| eyre!("couldnt find directory with local runtimes"))?;
+    let path = Path::new(KIT_CACHE);
     for entry in fs::read_dir(&path)? {
         let entry = entry?;
         let path = entry.path();

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -495,9 +495,16 @@ fn get_file_modified_time(file_path: &Path) -> Result<SystemTime> {
 
 #[instrument(level = "trace", skip_all)]
 fn get_cargo_package_path(package: &cargo_metadata::Package) -> Result<PathBuf> {
-    match package.manifest_path.parent().map(|p| p.as_std_path().to_path_buf()) {
+    match package
+        .manifest_path
+        .parent()
+        .map(|p| p.as_std_path().to_path_buf())
+    {
         Some(p) => Ok(p),
-        None => Err(eyre!("Cargo manifest path {} has no parent", package.manifest_path)),
+        None => Err(eyre!(
+            "Cargo manifest path {} has no parent",
+            package.manifest_path
+        )),
     }
 }
 
@@ -562,8 +569,6 @@ fn is_up_to_date(
     }
     Ok(false)
 }
-
-
 
 #[instrument(level = "trace", skip_all)]
 async fn compile_javascript_wasm_process(


### PR DESCRIPTION
## Problem

`boot-fake-node`s offline cache-fallback logic is flawed

## Solution

Fix it

## Docs Update

None

## Notes

h/t @jurij-jukic 