### PR TITLE
build: add `--reproducible` flag, using docker

### DIFF
--- a/src/build/Dockerfile.buildpackage
+++ b/src/build/Dockerfile.buildpackage
@@ -1,0 +1,14 @@
+FROM nick1udwig/buildbase:latest
+
+ENV NVM_DIR=/root/.nvm \
+    PATH="/root/.nvm/versions/node/$(node -v)/bin:${PATH}"
+
+RUN . ~/.bashrc \
+    && . ~/.cargo/env \
+    && . $NVM_DIR/nvm.sh \
+    && cargo install --git https://github.com/kinode-dao/kit --locked --branch v0.7.7
+
+WORKDIR /input
+
+# Set the default command to run the build script
+CMD ["/bin/bash", "-c", ". ~/.bashrc && . ~/.cargo/env && . $NVM_DIR/nvm.sh && kit build /input && find /input -type d -exec chmod 777 {} + && find /input -type f -exec chmod 666 {} +"]

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1436,14 +1436,13 @@ pub async fn execute(
         let source = package_dir.canonicalize().unwrap();
         let source = source.to_str().unwrap();
         run_command(
-            Command::new("docker")
-                .args(&[
-                    "run",
-                    "--rm",
-                    "--mount",
-                    &format!("type=bind,source={source},target=/input"),
-                    &format!("nick1udwig/buildpackage:{version}"),
-                ]),
+            Command::new("docker").args(&[
+                "run",
+                "--rm",
+                "--mount",
+                &format!("type=bind,source={source},target=/input"),
+                &format!("nick1udwig/buildpackage:{version}"),
+            ]),
             true,
         )?;
         return Ok(());

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1439,10 +1439,7 @@ pub async fn execute(
         let source = source.to_str().unwrap();
         // get latest version of image
         run_command(
-            Command::new("docker").args(&[
-                "pull",
-                &format!("nick1udwig/buildpackage:{version}"),
-            ]),
+            Command::new("docker").args(&["pull", &format!("nick1udwig/buildpackage:{version}")]),
             true,
         )?;
         run_command(

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1437,6 +1437,14 @@ pub async fn execute(
         let version = env!("CARGO_PKG_VERSION");
         let source = package_dir.canonicalize().unwrap();
         let source = source.to_str().unwrap();
+        // get latest version of image
+        run_command(
+            Command::new("docker").args(&[
+                "pull",
+                &format!("nick1udwig/buildpackage:{version}"),
+            ]),
+            true,
+        )?;
         run_command(
             Command::new("docker").args(&[
                 "run",

--- a/src/build_start_package/mod.rs
+++ b/src/build_start_package/mod.rs
@@ -18,6 +18,7 @@ pub async fn execute(
     default_world: Option<&str>,
     local_dependencies: Vec<PathBuf>,
     add_paths_to_api: Vec<PathBuf>,
+    reproducible: bool,
     force: bool,
     verbose: bool,
 ) -> Result<()> {
@@ -32,6 +33,7 @@ pub async fn execute(
         default_world,
         local_dependencies,
         add_paths_to_api,
+        reproducible,
         force,
         verbose,
         false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,6 +211,7 @@ async fn execute(
                 .unwrap_or_default()
                 .map(|s| PathBuf::from(s))
                 .collect();
+            let reproducible = matches.get_one::<bool>("REPRODUCIBLE").unwrap();
             let force = matches.get_one::<bool>("FORCE").unwrap();
             let verbose = matches.get_one::<bool>("VERBOSE").unwrap();
 
@@ -225,6 +226,7 @@ async fn execute(
                 default_world.map(|w| w.as_str()),
                 local_dependencies,
                 add_paths_to_api,
+                *reproducible,
                 *force,
                 *verbose,
                 false,
@@ -258,6 +260,7 @@ async fn execute(
                 .unwrap_or_default()
                 .map(|s| PathBuf::from(s))
                 .collect();
+            let reproducible = matches.get_one::<bool>("REPRODUCIBLE").unwrap();
             let force = matches.get_one::<bool>("FORCE").unwrap();
             let verbose = matches.get_one::<bool>("VERBOSE").unwrap();
 
@@ -272,6 +275,7 @@ async fn execute(
                 default_world.map(|w| w.as_str()),
                 local_dependencies,
                 add_paths_to_api,
+                *reproducible,
                 *force,
                 *verbose,
             )
@@ -690,6 +694,13 @@ async fn make_app(current_dir: &std::ffi::OsString) -> Result<Command> {
                 .long("add-to-api")
                 .help("Path to file to add to api.zip (can specify multiple times)")
             )
+            .arg(Arg::new("REPRODUCIBLE")
+                .action(ArgAction::SetTrue)
+                .short('r')
+                .long("reproducible")
+                .help("Make a reproducible build using Docker")
+                .required(false)
+            )
             .arg(Arg::new("FORCE")
                 .action(ArgAction::SetTrue)
                 .short('f')
@@ -770,6 +781,13 @@ async fn make_app(current_dir: &std::ffi::OsString) -> Result<Command> {
                 .action(ArgAction::Set)
                 .long("features")
                 .help("Pass these comma-delimited feature flags to Rust cargo builds")
+                .required(false)
+            )
+            .arg(Arg::new("REPRODUCIBLE")
+                .action(ArgAction::SetTrue)
+                .short('r')
+                .long("reproducible")
+                .help("Make a reproducible build using Docker")
                 .required(false)
             )
             .arg(Arg::new("FORCE")

--- a/src/publish/mod.rs
+++ b/src/publish/mod.rs
@@ -93,7 +93,7 @@ pub fn make_local_file_link_path(path: &Path, text: &str) -> Result<String> {
 }
 
 pub fn make_remote_link(url: &str, text: &str) -> String {
-    format!("\x1B]8;;{}\x1B\\{}\x1B]8;;\x1B\\", url, text,)
+    format!("\x1B]8;;{}\x1B\\{}\x1B]8;;\x1B\\", url, text)
 }
 
 fn is_valid_kimap_package_name(s: &str) -> bool {

--- a/src/run_tests/mod.rs
+++ b/src/run_tests/mod.rs
@@ -370,6 +370,7 @@ async fn build_packages(
             false,
             false,
             false,
+            false,
         )
         .await?;
         start_package::execute(&path, &url).await?;
@@ -390,6 +391,7 @@ async fn build_packages(
             false,
             false,
             false,
+            false,
         )
         .await?;
     }
@@ -405,6 +407,7 @@ async fn build_packages(
             None,
             dependency_package_paths.clone(),
             vec![], // TODO
+            false,
             false,
             false,
             false,


### PR DESCRIPTION
## Problem

Would be nice to be able to reproducibly build packages. See, e.g., https://github.com/kinode-dao/kinode/pull/553

## Solution

Incorporate the package-building image into `kit`.

## Docs Update

TODO

## Notes

None