### PR TITLE
fix template: import println in blank

### DIFF
--- a/src/new/templates/rust/no-ui/blank/blank/src/lib.rs
+++ b/src/new/templates/rust/no-ui/blank/blank/src/lib.rs
@@ -1,4 +1,4 @@
-use kinode_process_lib::{await_message, call_init, Address};
+use kinode_process_lib::{await_message, call_init, println, Address};
 
 wit_bindgen::generate!({
     path: "target/wit",


### PR DESCRIPTION
## Problem

The blank template prints out received messages and errors, but they won't print without the import.

## Solution

import println!

## Docs Update

Not needed I think?

## Notes

Looked through other templates if any had the same issue, didn't find one.