### PR TITLE
build: improve UI building

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "kit"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "alloy",
  "alloy-sol-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kit"
-version = "0.7.7"
+version = "0.8.0"
 edition = "2021"
 
 [build-dependencies]

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -100,7 +100,7 @@ fn zip_directory(directory: &Path, zip_filename: &str) -> Result<()> {
     let options = FileOptions::default()
         .compression_method(zip::CompressionMethod::Deflated)
         .unix_permissions(0o755)
-        .last_modified_time(zip::DateTime::from_date_and_time(1980, 1, 1, 0, 0, 0).unwrap());
+        .last_modified_time(zip::DateTime::from_date_and_time(2023, 6, 19, 0, 0, 0).unwrap());
 
     let mut walk_dir = WalkDir::new(directory)
         .into_iter()

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1210,7 +1210,10 @@ fn get_ui_dirs(package_dir: &Path) -> Result<Vec<PathBuf>> {
         .read_dir()?
         .filter_map(|entry| {
             let path = entry.ok()?.path();
-            if path.is_dir() && path.join(PACKAGE_JSON_NAME).exists() && !path.join(COMPONENTIZE_MJS_NAME).exists() {
+            if path.is_dir()
+                && path.join(PACKAGE_JSON_NAME).exists()
+                && !path.join(COMPONENTIZE_MJS_NAME).exists()
+            {
                 // is dir AND is js AND is not component -> is UI: add to Vec
                 Some(path)
             } else {
@@ -1347,12 +1350,8 @@ async fn compile_package(
 ) -> Result<()> {
     let metadata = read_and_update_metadata(package_dir)?;
     let mut wasm_paths = HashSet::new();
-    let (mut apis, dependencies) = check_and_populate_dependencies(
-        package_dir,
-        &metadata,
-        skip_deps_check,
-        verbose,
-    )?;
+    let (mut apis, dependencies) =
+        check_and_populate_dependencies(package_dir, &metadata, skip_deps_check, verbose)?;
 
     if !ignore_deps && !dependencies.is_empty() {
         fetch_dependencies(
@@ -1469,7 +1468,9 @@ pub async fn execute(
     ignore_deps: bool, // for internal use; may cause problems when adding recursive deps
 ) -> Result<()> {
     if no_ui && ui_only {
-        return Err(eyre!("Cannot set both `no_ui` and `ui_only` to true at the same time"));
+        return Err(eyre!(
+            "Cannot set both `no_ui` and `ui_only` to true at the same time"
+        ));
     }
     if !package_dir.join("pkg").exists() {
         if Some(".DS_Store") == package_dir.file_name().and_then(|s| s.to_str()) {


### PR DESCRIPTION
## Problem

Resolves #253

## Solution

Identify UI directories based on contents, like how we identify process directories. This means users can have arbitrarily many UI directories.

## Docs Update

TODO

## Notes

BREAKING CHANGE: `kit build` will no longer "build" static `ui/` by copying its contents to `pkg`. If you used this functionality, please move your static `ui/` directory into the `pkg/` directory.