### PR TITLE
no cab fr fr

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -825,17 +825,22 @@ async fn compile_rust_wasm_process(
     // Adapt the module using wasm-tools
 
     // For use inside of process_dir
-    let wasm_file_name = process_dir
+    // Run `wasm-tools component new`, putting output in pkg/
+    //  and rewriting all `_`s to `-`s
+    // cargo hates `-`s and so outputs with `_`s; Kimap hates
+    //  `_`s and so we convert to and enforce all `-`s
+    let wasm_file_name_cab = process_dir
         .file_name()
         .and_then(|s| s.to_str())
         .unwrap()
         .replace("-", "_");
+    let wasm_file_name_hep = wasm_file_name_cab.replace("_", "-");
 
     let wasm_file_prefix = Path::new("target/wasm32-wasip1/release");
-    let wasm_file = wasm_file_prefix.join(&format!("{}.wasm", wasm_file_name));
+    let wasm_file_cab = wasm_file_prefix.join(&format!("{wasm_file_name_cab}.wasm"));
 
-    let wasm_path = format!("../pkg/{}.wasm", wasm_file_name);
-    let wasm_path = Path::new(&wasm_path);
+    let wasm_file_pkg = format!("../pkg/{wasm_file_name_hep}.wasm");
+    let wasm_file_pkg = Path::new(&wasm_file_pkg);
 
     let wasi_snapshot_file = Path::new("target/wasi_snapshot_preview1.wasm");
 
@@ -844,9 +849,9 @@ async fn compile_rust_wasm_process(
             .args(&[
                 "component",
                 "new",
-                wasm_file.to_str().unwrap(),
+                wasm_file_cab.to_str().unwrap(),
                 "-o",
-                wasm_path.to_str().unwrap(),
+                wasm_file_pkg.to_str().unwrap(),
                 "--adapt",
                 wasi_snapshot_file.to_str().unwrap(),
             ])

--- a/src/start_package/mod.rs
+++ b/src/start_package/mod.rs
@@ -85,10 +85,13 @@ fn install(
 fn check_manifest(pkg_dir: &Path, manifest_file_name: &str) -> Result<()> {
     let manifest_path = pkg_dir.join(manifest_file_name);
     let book_link = make_remote_link("https://book.kinode.org/my_first_app/chapter_1.html?highlight=manifest.json#pkgmanifestjson", "Kinode book");
-    let manifest = fs::File::open(&manifest_path)
-        .with_suggestion(|| format!("Missing required manifest.json file. See discussion {book_link}"))?;
-    let manifest: Vec<PackageManifestEntry> = serde_json::from_reader(manifest)
-        .with_suggestion(|| format!("Failed to parse required manifest.json file. See discussion {book_link}"))?;
+    let manifest = fs::File::open(&manifest_path).with_suggestion(|| {
+        format!("Missing required manifest.json file. See discussion {book_link}")
+    })?;
+    let manifest: Vec<PackageManifestEntry> =
+        serde_json::from_reader(manifest).with_suggestion(|| {
+            format!("Failed to parse required manifest.json file. See discussion {book_link}")
+        })?;
     let manifest_json = make_local_file_link_path(&manifest_path, "manifest.json")?;
     for entry in &manifest {
         let file_name = &entry.process_name;

--- a/src/start_package/mod.rs
+++ b/src/start_package/mod.rs
@@ -8,7 +8,8 @@ use tracing::{info, instrument};
 use kinode_process_lib::kernel_types::{Erc721Metadata, PackageManifestEntry};
 
 use crate::build::{hash_zip_pkg, make_pkg_publisher, make_zip_filename, read_and_update_metadata};
-use crate::publish::make_local_file_link_path;
+use crate::new::is_kimap_safe;
+use crate::publish::{make_local_file_link_path, make_remote_link};
 use crate::{inject_message, KIT_LOG_PATH_DEFAULT};
 
 #[instrument(level = "trace", skip_all)]
@@ -82,10 +83,35 @@ fn install(
 
 #[instrument(level = "trace", skip_all)]
 fn check_manifest(pkg_dir: &Path, manifest_file_name: &str) -> Result<()> {
-    let manifest = fs::File::open(pkg_dir.join(manifest_file_name))
-        .with_suggestion(|| format!("Missing required {} file. See discussion at https://book.kinode.org/my_first_app/chapter_1.html?highlight=manifest.json#pkgmanifestjson", manifest_file_name))?;
+    let manifest_path = pkg_dir.join(manifest_file_name);
+    let book_link = make_remote_link("https://book.kinode.org/my_first_app/chapter_1.html?highlight=manifest.json#pkgmanifestjson", "Kinode book");
+    let manifest = fs::File::open(&manifest_path)
+        .with_suggestion(|| format!("Missing required manifest.json file. See discussion {book_link}"))?;
     let manifest: Vec<PackageManifestEntry> = serde_json::from_reader(manifest)
-        .with_suggestion(|| format!("Failed to parse required {} file. See discussion at https://book.kinode.org/my_first_app/chapter_1.html?highlight=manifest.json#pkgmanifestjson", manifest_file_name))?;
+        .with_suggestion(|| format!("Failed to parse required manifest.json file. See discussion {book_link}"))?;
+    let manifest_json = make_local_file_link_path(&manifest_path, "manifest.json")?;
+    for entry in &manifest {
+        let file_name = &entry.process_name;
+        let file_path = entry.process_wasm_path
+            .strip_prefix("/")
+            .and_then(|s| s.strip_suffix(".wasm"))
+            .ok_or_else(|| {
+
+                eyre!(
+                    "{manifest_json} has unexpected Wasm path: {:?} (expected beginning `/` and ending `.wasm`)",
+                    entry.process_wasm_path,
+                )
+            })?;
+        if !is_kimap_safe(file_name, false) {
+            return Err(eyre!("{manifest_json} file name '{file_name}' must be Kimap safe (a-z, A-Z, 0-9, - allowed)"));
+        }
+        if !is_kimap_safe(file_path, false) {
+            return Err(eyre!(
+                "{manifest_json} file path {:?} must be Kimap safe (a-z, A-Z, 0-9, - allowed)",
+                entry.process_wasm_path,
+            ));
+        }
+    }
     let has_all_entries = manifest.iter().fold(true, |has_all_entries, entry| {
         let file_path = entry
             .process_wasm_path


### PR DESCRIPTION
## Problem

#216 https://github.com/kinode-dao/kinode/issues/527

We want to be strict about `-`s within Kinode to match Kimap.

## Solution

1. Don't allow `kit new`s that have `_`s.
2. Don't allow existing that have `_`s to build/etc.

## Docs Update

TODO

## Notes

BREAKING CHANGES: 
1. Don't allow `kit new`s that have `_`s.
2. Don't allow existing that have `_`s to build/etc.