### PR TITLE
build: temporarily drop non rust support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1024,7 +1024,8 @@ async fn make_app(current_dir: &std::ffi::OsString) -> Result<Command> {
                 .short('l')
                 .long("language")
                 .help("Programming language of the template")
-                .value_parser(["rust", "python", "javascript"])
+                .value_parser(["rust"])
+                //.value_parser(["rust", "python", "javascript"]) // TODO: resupport
                 .default_value("rust")
             )
             .arg(Arg::new("TEMPLATE")

--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -171,6 +171,11 @@ fn replace_vars(
         .replace(
             &format!("{template_package_name}-"),
             &format!("{package_name_kebab}-"),
+        )
+        // function call
+        .replace(
+            &format!("{template_package_name}("),
+            &format!("{package_name_snake}("),
         );
     let input = if extension == "wit" {
         input

--- a/src/new/templates/rust/no-ui/file-transfer/file-transfer/Cargo.toml
+++ b/src/new/templates/rust/no-ui/file-transfer/file-transfer/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[features]
+test = []
+
 [dependencies]
 anyhow = "1.0"
 kinode_process_lib = { version = "0.9.6", features = ["logging"] }

--- a/src/new/templates/rust/no-ui/file-transfer/test/file-transfer-test/api/file-transfer-test:template.os-v0.wit
+++ b/src/new/templates/rust/no-ui/file-transfer/test/file-transfer-test/api/file-transfer-test:template.os-v0.wit
@@ -1,5 +1,6 @@
 world file-transfer-test-template-dot-os-v0 {
     import file-transfer;
+    import file-transfer-worker;
     import tester;
     include process-v0;
 }

--- a/src/new/templates/rust/no-ui/file-transfer/test/file-transfer-test/file-transfer-test/Cargo.toml
+++ b/src/new/templates/rust/no-ui/file-transfer/test/file-transfer-test/file-transfer-test/Cargo.toml
@@ -6,13 +6,10 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
-bincode = "1.3"
 kinode_process_lib = "0.9.2"
 process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
-rmp-serde = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-thiserror = "1.0"
 wit-bindgen = "0.24.0"
 
 [lib]

--- a/src/new/templates/rust/no-ui/file-transfer/test/file-transfer-test/file-transfer-test/src/lib.rs
+++ b/src/new/templates/rust/no-ui/file-transfer/test/file-transfer-test/file-transfer-test/src/lib.rs
@@ -1,6 +1,8 @@
 use crate::kinode::process::file_transfer::{
-    Address as WitAddress, DownloadRequest, FileInfo, InitializeRequest, ProgressRequest,
-    Request as TransferRequest, Response as TransferResponse, WorkerRequest,
+    FileInfo, Request as TransferRequest, Response as TransferResponse,
+};
+use crate::kinode::process::file_transfer_worker::{
+    Address as WitAddress, DownloadRequest, Request as WorkerRequest,
 };
 use crate::kinode::process::standard::ProcessId as WitProcessId;
 use crate::kinode::process::tester::{
@@ -8,7 +10,8 @@ use crate::kinode::process::tester::{
 };
 
 use kinode_process_lib::{
-    await_message, call_init, print_to_terminal, println, Address, ProcessId, Request, Response,
+    await_message, call_init, our_capabilities, print_to_terminal, println, save_capabilities,
+    vfs::File, Address, ProcessId, Request, Response,
 };
 
 mod tester_lib;
@@ -20,36 +23,137 @@ wit_bindgen::generate!({
     additional_derives: [PartialEq, serde::Deserialize, serde::Serialize, process_macros::SerdeJsonInto],
 });
 
-fn test_list_files(address: &Address) -> anyhow::Result<Vec<FileInfo>> {
+const FILE_NAME: &str = "my_file.txt";
+const FILE_CONTENTS: &str = "hi";
+const DRIVE_PATH: &str = "file-transfer:template.os";
+
+impl From<Address> for WitAddress {
+    fn from(address: Address) -> Self {
+        WitAddress {
+            node: address.node,
+            process: address.process.into(),
+        }
+    }
+}
+
+impl From<ProcessId> for WitProcessId {
+    fn from(process: ProcessId) -> Self {
+        WitProcessId {
+            process_name: process.process_name,
+            package_name: process.package_name,
+            publisher_node: process.publisher_node,
+        }
+    }
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize, process_macros::SerdeJsonInto)]
+enum Setup {
+    Caps,
+    WriteFile { name: String, contents: Vec<u8> },
+}
+
+fn make_ft_address(node: &str) -> Address {
+    Address {
+        node: node.to_string(),
+        process: ProcessId::new(Some("file-transfer"), "file-transfer", "template.os"),
+    }
+}
+
+fn make_file_path() -> String {
+    format!("{DRIVE_PATH}/files/{FILE_NAME}")
+}
+
+fn setup(our: &Address, their: &str) -> anyhow::Result<()> {
+    let our_ft_address = make_ft_address(&our.node);
+    let their_ft_address = make_ft_address(their);
+
+    // write file on their
+    Request::new()
+        .target(their_ft_address.clone())
+        .body(Setup::WriteFile {
+            name: FILE_NAME.to_string(),
+            contents: FILE_CONTENTS.as_bytes().to_vec(),
+        })
+        .send()?;
+
+    // caps on our
+    println!("file-transfer-test: started caps handshake...");
+
     let response = Request::new()
-        .target(address)
+        .target(our_ft_address.clone())
+        .body(Setup::Caps)
+        .send_and_await_response(5)??;
+
+    save_capabilities(response.capabilities());
+    println!("file-transfer-test: got caps {:#?}", our_capabilities());
+
+    Ok(())
+}
+
+fn test_list_files(our_ft_address: &Address, their_ft_address: &Address) -> anyhow::Result<()> {
+    // our: none
+    let response = Request::new()
+        .target(our_ft_address)
         .body(TransferRequest::ListFiles)
         .send_and_await_response(15)?
         .unwrap();
     if response.is_request() {
         fail!("file-transfer-test");
     };
-    let TransferResponse::ListFiles(files) = response.body().try_into()? else {
+    let TransferResponse::ListFiles(files) = response.body().try_into()?;
+    println!("{files:?}");
+    if files.len() != 0 {
+        fail!("file-transfer-test");
+    }
+
+    // their: one
+    let response = Request::new()
+        .target(their_ft_address)
+        .body(TransferRequest::ListFiles)
+        .send_and_await_response(15)?
+        .unwrap();
+    if response.is_request() {
         fail!("file-transfer-test");
     };
-    Ok(files)
+    let TransferResponse::ListFiles(files) = response.body().try_into()?;
+    println!("{files:?}");
+    if files.len() != 1 {
+        fail!("file-transfer-test");
+    }
+    let file = files[0].clone();
+    let expected_file_info = FileInfo {
+        name: make_file_path(),
+        size: FILE_CONTENTS.len() as u64,
+    };
+    if file != expected_file_info {
+        fail!("file-transfer-test");
+    }
+    Ok(())
 }
 
-fn test_download(name: String, our: &Address, address: &Address) -> anyhow::Result<()> {
+fn test_download(our_ft_address: &Address, their_ft_address: &Address) -> anyhow::Result<()> {
     let response = Request::new()
-        .target(our)
-        .body(TransferRequest::Download(DownloadRequest {
-            name,
-            target: address,
+        .target(our_ft_address)
+        .body(WorkerRequest::Download(DownloadRequest {
+            name: FILE_NAME.to_string(),
+            target: their_ft_address.clone().into(),
+            is_requestor: true,
         }))
         .send_and_await_response(15)?
         .unwrap();
     if response.is_request() {
         fail!("file-transfer-test");
     };
-    let TransferResponse::Download = response.body().try_into()? else {
-        fail!("file-transfer-test");
+    std::thread::sleep(std::time::Duration::from_secs(3));
+
+    let file = File {
+        path: make_file_path(),
+        timeout: 5,
     };
+    let file_contents = file.read()?;
+    if file_contents != FILE_CONTENTS.as_bytes() {
+        fail!("file-transfer-test");
+    }
     Ok(())
 }
 
@@ -72,60 +176,47 @@ fn handle_message(our: &Address) -> anyhow::Result<()> {
     }) = message.body().try_into()?;
     print_to_terminal(0, "file-transfer-test: a");
     assert!(node_names.len() >= 2);
-    if our.node != node_names[0] {
-        // we are not master node: return
-        Response::new()
-            .body(TesterResponse::Run(Ok(())))
-            .send()
-            .unwrap();
-        return Ok(());
-    }
-
     // we are master node
+    assert!(our.node == node_names[0]);
 
-    let our_ft_address = Address {
-        node: our.node.clone(),
-        process: ProcessId::new(Some("file-transfer"), "file-transfer", "template.os"),
-    };
-    let their_ft_address = Address {
-        node: node_names[1].clone(),
-        process: ProcessId::new(Some("file-transfer"), "file-transfer", "template.os"),
-    };
-
-    // Send
-    print_to_terminal(0, "file-transfer-test: b");
-    let message: String = "hello".into();
-    let _ = Request::new()
-        .target(our_ft_address.clone())
-        .body(ChatRequest::Send(SendRequest {
-            target: node_names[1].clone(),
-            message: message.clone(),
-        }))
-        .send_and_await_response(15)?
-        .unwrap();
-
-    // Get history from receiver & test
-    print_to_terminal(0, "file-transfer-test: c");
-    let response = Request::new()
-        .target(their_ft_address.clone())
-        .body(ChatRequest::History(our.node.clone()))
-        .send_and_await_response(15)?
-        .unwrap();
-    if response.is_request() {
-        fail!("file-transfer-test");
-    };
-    let ChatResponse::History(messages) = response.body().try_into()? else {
-        fail!("file-transfer-test");
-    };
-    let expected_messages = vec![ChatMessage {
-        author: our.node.clone(),
-        content: message,
-    }];
-
-    if messages != expected_messages {
-        println!("{messages:?} != {expected_messages:?}");
+    if setup(&our, &node_names[1]).is_err() {
         fail!("file-transfer-test");
     }
+
+    let our_ft_address = make_ft_address(&our.node);
+    let their_ft_address = make_ft_address(&node_names[1]);
+
+    if test_list_files(&our_ft_address, &their_ft_address).is_err() {
+        fail!("file-transfer-test");
+    }
+
+    // Test file_transfer_worker
+    println!("file-transfer-test: b");
+    if test_download(&our_ft_address, &their_ft_address).is_err() {
+        fail!("file-transfer-test");
+    }
+    //let response = Request::new()
+    //    .target(our_ft_address.clone())
+    //    .body(WorkerRequest::Download(DownloadRequest {
+    //        name: FILE_NAME.to_string(),
+    //        target: their_ft_address.into(),
+    //        is_requestor: true,
+    //    }))
+    //    .send_and_await_response(15)?
+    //    .unwrap();
+    //if response.is_request() {
+    //    fail!("file-transfer-test");
+    //};
+    //std::thread::sleep(std::time::Duration::from_secs(3));
+
+    //let file = File {
+    //    path: format!("{DRIVE_PATH}/files/{FILE_NAME}"),
+    //    timeout: 5,
+    //};
+    //let file_contents = file.read()?;
+    //if file_contents != FILE_CONTENTS.as_bytes() {
+    //    fail!("file-transfer-test");
+    //}
 
     Response::new()
         .body(TesterResponse::Run(Ok(())))

--- a/src/new/templates/rust/no-ui/file-transfer/test/tests.toml
+++ b/src/new/templates/rust/no-ui/file-transfer/test/tests.toml
@@ -5,6 +5,7 @@ runtime_build_release = false
 
 
 [[tests]]
+dependency_package_paths = [".."]
 setup_packages = [
     { path = "..", run = true }
 ]


### PR DESCRIPTION
## Problem

We don't put much effort into maintaining support for anything but Rust

## Solution

Remove other language templates for now

## Docs Update

TODO

## Notes

None