### PR TITLE
improve robustness of runtime build

### DIFF
--- a/src/boot_fake_node/mod.rs
+++ b/src/boot_fake_node/mod.rs
@@ -79,7 +79,12 @@ pub fn extract_zip(archive_path: &Path) -> Result<()> {
 pub fn compile_runtime(path: &Path, release: bool, is_simulation_mode: bool) -> Result<()> {
     info!("Compiling Kinode runtime...");
 
-    let mut args = vec!["+nightly", "build", "-p", "kinode", "--color=always"];
+    // build the packages
+    let args = vec!["run", "-p", "build-packages", "--", "--features", "simulation-mode"];
+    build::run_command(Command::new("cargo").args(&args).current_dir(path), false)?;
+
+    // build the runtime
+    let mut args = vec!["build", "-p", "kinode", "--color=always"];
     if release {
         args.push("--release");
     }
@@ -87,7 +92,13 @@ pub fn compile_runtime(path: &Path, release: bool, is_simulation_mode: bool) -> 
         args.extend_from_slice(&["--features", "simulation-mode"]);
     }
 
-    build::run_command(Command::new("cargo").args(&args).current_dir(path), false)?;
+    build::run_command(
+        Command::new("cargo")
+            .env("PATH_TO_PACKAGES_ZIP", "target/packages-simulation-mode.zip")
+            .args(&args)
+            .current_dir(path),
+        false,
+    )?;
 
     info!("Done compiling Kinode runtime.");
     Ok(())

--- a/src/boot_fake_node/mod.rs
+++ b/src/boot_fake_node/mod.rs
@@ -80,7 +80,14 @@ pub fn compile_runtime(path: &Path, release: bool, is_simulation_mode: bool) -> 
     info!("Compiling Kinode runtime...");
 
     // build the packages
-    let args = vec!["run", "-p", "build-packages", "--", "--features", "simulation-mode"];
+    let args = vec![
+        "run",
+        "-p",
+        "build-packages",
+        "--",
+        "--features",
+        "simulation-mode",
+    ];
     build::run_command(Command::new("cargo").args(&args).current_dir(path), false)?;
 
     // build the runtime
@@ -94,7 +101,10 @@ pub fn compile_runtime(path: &Path, release: bool, is_simulation_mode: bool) -> 
 
     build::run_command(
         Command::new("cargo")
-            .env("PATH_TO_PACKAGES_ZIP", "target/packages-simulation-mode.zip")
+            .env(
+                "PATH_TO_PACKAGES_ZIP",
+                "target/packages-simulation-mode.zip",
+            )
             .args(&args)
             .current_dir(path),
         false,


### PR DESCRIPTION
## Problem

Building runtime doesn't work on a clean-slate Kinode core

## Solution

Fix it (see also https://github.com/kinode-dao/kinode/commit/8200ecb6a73adffe8a044b26b9a68f86f3901802).

## Docs Update

None

## Notes

None