### PR TITLE
bump wit-bindgen to 0.36 and use wit v1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ color-eyre = { version = "0.6", features = ["capture-spantrace"] }
 dirs = "5.0"
 fs-err = "2.11"
 hex = "0.4"
-kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib.git", rev = "9ac9e51" }
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib.git", rev = "2a526c8" }
 nix = { version = "0.27", features = ["process", "signal", "term"] }
 regex = "1"
 reqwest = { version = "0.12", features = ["json"] }
@@ -65,7 +65,7 @@ tracing-appender = "0.2"
 tracing-error = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "std"] }
 walkdir = "2.4"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 zip = "0.6"
 
 [workspace]

--- a/src/new/templates/javascript/no-ui/chat/api/chat:template.os-v0.wit
+++ b/src/new/templates/javascript/no-ui/chat/api/chat:template.os-v0.wit
@@ -23,5 +23,5 @@ interface chat {
 
 world chat-template-dot-os-v0 {
     import chat;
-    include process;
+    include process-v1;
 }

--- a/src/new/templates/javascript/no-ui/chat/pkg/manifest.json
+++ b/src/new/templates/javascript/no-ui/chat/pkg/manifest.json
@@ -5,7 +5,7 @@
         "on_exit": "Restart",
         "request_networking": true,
         "request_capabilities": [
-            "http_server:distro:sys"
+            "http-server:distro:sys"
         ],
         "grant_capabilities": [],
         "public": true

--- a/src/new/templates/javascript/no-ui/chat/send/Cargo.toml
+++ b/src/new/templates/javascript/no-ui/chat/send/Cargo.toml
@@ -6,10 +6,10 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
-kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "84b3d84" }
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/javascript/no-ui/chat/test/chat_test/api/chat_test:template.os-v0.wit
+++ b/src/new/templates/javascript/no-ui/chat/test/chat_test/api/chat_test:template.os-v0.wit
@@ -1,5 +1,5 @@
 world chat-test-template-dot-os-v0 {
     import chat;
     import tester;
-    include process-v0;
+    include process-v1;
 }

--- a/src/new/templates/javascript/no-ui/chat/test/chat_test/chat_test/Cargo.toml
+++ b/src/new/templates/javascript/no-ui/chat/test/chat_test/chat_test/Cargo.toml
@@ -7,13 +7,13 @@ publish = false
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3"
-kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.8.3" }
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8" }
 process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 rmp-serde = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/javascript/no-ui/chat/test/chat_test/metadata.json
+++ b/src/new/templates/javascript/no-ui/chat/test/chat_test/metadata.json
@@ -10,7 +10,7 @@
         "code_hashes": {
             "0.1.0": ""
         },
-        "wit_version": 0,
+        "wit_version": 1,
         "dependencies": [
             "chat:template.os",
             "tester:sys"

--- a/src/new/templates/javascript/no-ui/echo/pkg/manifest.json
+++ b/src/new/templates/javascript/no-ui/echo/pkg/manifest.json
@@ -5,7 +5,7 @@
         "on_exit": "Restart",
         "request_networking": true,
         "request_capabilities": [
-            "http_server:distro:sys"
+            "http-server:distro:sys"
         ],
         "grant_capabilities": [],
         "public": true

--- a/src/new/templates/javascript/no-ui/echo/test/echo_test/api/echo_test:template.os-v0.wit
+++ b/src/new/templates/javascript/no-ui/echo/test/echo_test/api/echo_test:template.os-v0.wit
@@ -1,4 +1,4 @@
 world echo-test-template-dot-os-v0 {
     import tester;
-    include process-v0;
+    include process-v1;
 }

--- a/src/new/templates/javascript/no-ui/echo/test/echo_test/echo_test/Cargo.toml
+++ b/src/new/templates/javascript/no-ui/echo/test/echo_test/echo_test/Cargo.toml
@@ -7,13 +7,13 @@ publish = false
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3"
-kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.8.3" }
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8" }
 process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 rmp-serde = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/javascript/no-ui/echo/test/echo_test/metadata.json
+++ b/src/new/templates/javascript/no-ui/echo/test/echo_test/metadata.json
@@ -10,7 +10,7 @@
         "code_hashes": {
             "0.1.0": ""
         },
-        "wit_version": 0,
+        "wit_version": 1,
         "dependencies": [
             "tester:sys"
         ]

--- a/src/new/templates/javascript/no-ui/fibonacci/pkg/manifest.json
+++ b/src/new/templates/javascript/no-ui/fibonacci/pkg/manifest.json
@@ -5,7 +5,7 @@
         "on_exit": "Restart",
         "request_networking": true,
         "request_capabilities": [
-            "http_server:distro:sys"
+            "http-server:distro:sys"
         ],
         "grant_capabilities": [],
         "public": true

--- a/src/new/templates/javascript/no-ui/fibonacci/test/fibonacci_test/api/fibonacci_test:template.os-v0.wit
+++ b/src/new/templates/javascript/no-ui/fibonacci/test/fibonacci_test/api/fibonacci_test:template.os-v0.wit
@@ -1,5 +1,5 @@
 world fibonacci-test-template-dot-os-v0 {
     import fibonacci;
     import tester;
-    include process-v0;
+    include process-v1;
 }

--- a/src/new/templates/javascript/no-ui/fibonacci/test/fibonacci_test/fibonacci_test/Cargo.toml
+++ b/src/new/templates/javascript/no-ui/fibonacci/test/fibonacci_test/fibonacci_test/Cargo.toml
@@ -6,11 +6,11 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
-kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.8.3" }
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8" }
 process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/javascript/no-ui/fibonacci/test/fibonacci_test/metadata.json
+++ b/src/new/templates/javascript/no-ui/fibonacci/test/fibonacci_test/metadata.json
@@ -10,7 +10,7 @@
         "code_hashes": {
             "0.1.0": ""
         },
-        "wit_version": 0,
+        "wit_version": 1,
         "dependencies": [
             "fibonacci:template.os",
             "tester:sys"

--- a/src/new/templates/python/no-ui/chat/api/chat:template.os-v0.wit
+++ b/src/new/templates/python/no-ui/chat/api/chat:template.os-v0.wit
@@ -23,5 +23,5 @@ interface chat {
 
 world chat-template-dot-os-v0 {
     import chat;
-    include process;
+    include process-v1;
 }

--- a/src/new/templates/python/no-ui/chat/pkg/manifest.json
+++ b/src/new/templates/python/no-ui/chat/pkg/manifest.json
@@ -5,7 +5,7 @@
         "on_exit": "Restart",
         "request_networking": true,
         "request_capabilities": [
-            "http_server:distro:sys"
+            "http-server:distro:sys"
         ],
         "grant_capabilities": [],
         "public": true

--- a/src/new/templates/python/no-ui/chat/test/chat_test/api/chat_test:template.os-v0.wit
+++ b/src/new/templates/python/no-ui/chat/test/chat_test/api/chat_test:template.os-v0.wit
@@ -1,5 +1,5 @@
 world chat-test-template-dot-os-v0 {
     import chat;
     import tester;
-    include process-v0;
+    include process-v1;
 }

--- a/src/new/templates/python/no-ui/chat/test/chat_test/chat_test/Cargo.toml
+++ b/src/new/templates/python/no-ui/chat/test/chat_test/chat_test/Cargo.toml
@@ -7,13 +7,13 @@ publish = false
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3"
-kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.8.3" }
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8" }
 process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 rmp-serde = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/python/no-ui/chat/test/chat_test/metadata.json
+++ b/src/new/templates/python/no-ui/chat/test/chat_test/metadata.json
@@ -10,7 +10,7 @@
         "code_hashes": {
             "0.1.0": ""
         },
-        "wit_version": 0,
+        "wit_version": 1,
         "dependencies": [
             "chat:template.os",
             "tester:sys"

--- a/src/new/templates/python/no-ui/echo/pkg/manifest.json
+++ b/src/new/templates/python/no-ui/echo/pkg/manifest.json
@@ -5,7 +5,7 @@
         "on_exit": "Restart",
         "request_networking": true,
         "request_capabilities": [
-            "http_server:distro:sys"
+            "http-server:distro:sys"
         ],
         "grant_capabilities": [],
         "public": true

--- a/src/new/templates/python/no-ui/echo/test/echo_test/api/echo_test:template.os-v0.wit
+++ b/src/new/templates/python/no-ui/echo/test/echo_test/api/echo_test:template.os-v0.wit
@@ -1,4 +1,4 @@
 world echo-test-template-dot-os-v0 {
     import tester;
-    include process-v0;
+    include process-v1;
 }

--- a/src/new/templates/python/no-ui/echo/test/echo_test/echo_test/Cargo.toml
+++ b/src/new/templates/python/no-ui/echo/test/echo_test/echo_test/Cargo.toml
@@ -7,13 +7,13 @@ publish = false
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3"
-kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.8.3" }
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8" }
 process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 rmp-serde = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/python/no-ui/echo/test/echo_test/metadata.json
+++ b/src/new/templates/python/no-ui/echo/test/echo_test/metadata.json
@@ -10,7 +10,7 @@
         "code_hashes": {
             "0.1.0": ""
         },
-        "wit_version": 0,
+        "wit_version": 1,
         "dependencies": [
             "tester:sys"
         ]

--- a/src/new/templates/python/no-ui/fibonacci/pkg/manifest.json
+++ b/src/new/templates/python/no-ui/fibonacci/pkg/manifest.json
@@ -5,7 +5,7 @@
         "on_exit": "Restart",
         "request_networking": true,
         "request_capabilities": [
-            "http_server:distro:sys"
+            "http-server:distro:sys"
         ],
         "grant_capabilities": [],
         "public": true

--- a/src/new/templates/python/no-ui/fibonacci/test/fibonacci_test/api/fibonacci_test:template.os-v0.wit
+++ b/src/new/templates/python/no-ui/fibonacci/test/fibonacci_test/api/fibonacci_test:template.os-v0.wit
@@ -1,5 +1,5 @@
 world fibonacci-test-template-dot-os-v0 {
     import fibonacci;
     import tester;
-    include process-v0;
+    include process-v1;
 }

--- a/src/new/templates/python/no-ui/fibonacci/test/fibonacci_test/fibonacci_test/Cargo.toml
+++ b/src/new/templates/python/no-ui/fibonacci/test/fibonacci_test/fibonacci_test/Cargo.toml
@@ -6,11 +6,11 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
-kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.8.3" }
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8" }
 process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/python/no-ui/fibonacci/test/fibonacci_test/metadata.json
+++ b/src/new/templates/python/no-ui/fibonacci/test/fibonacci_test/metadata.json
@@ -10,7 +10,7 @@
         "code_hashes": {
             "0.1.0": ""
         },
-        "wit_version": 0,
+        "wit_version": 1,
         "dependencies": [
             "fibonacci:template.os",
             "tester:sys"

--- a/src/new/templates/rust/no-ui/blank/blank/Cargo.toml
+++ b/src/new/templates/rust/no-ui/blank/blank/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-kinode_process_lib = "0.9.2"
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/rust/no-ui/blank/blank/src/lib.rs
+++ b/src/new/templates/rust/no-ui/blank/blank/src/lib.rs
@@ -2,7 +2,7 @@ use kinode_process_lib::{await_message, call_init, println, Address};
 
 wit_bindgen::generate!({
     path: "target/wit",
-    world: "process-v0",
+    world: "process-v1",
 });
 
 call_init!(init);

--- a/src/new/templates/rust/no-ui/blank/metadata.json
+++ b/src/new/templates/rust/no-ui/blank/metadata.json
@@ -10,7 +10,7 @@
         "code_hashes": {
             "0.1.0": ""
         },
-        "wit_version": 0,
+        "wit_version": 1,
         "dependencies": []
     },
     "external_url": "",

--- a/src/new/templates/rust/no-ui/chat/api/chat:template.os-v0.wit
+++ b/src/new/templates/rust/no-ui/chat/api/chat:template.os-v0.wit
@@ -23,5 +23,5 @@ interface chat {
 
 world chat-template-dot-os-v0 {
     import chat;
-    include process-v0;
+    include process-v1;
 }

--- a/src/new/templates/rust/no-ui/chat/chat/Cargo.toml
+++ b/src/new/templates/rust/no-ui/chat/chat/Cargo.toml
@@ -6,11 +6,11 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
-kinode_process_lib = { version = "0.9.6", features = ["logging"] }
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8", features = ["logging"] }
 process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/rust/no-ui/chat/metadata.json
+++ b/src/new/templates/rust/no-ui/chat/metadata.json
@@ -10,7 +10,7 @@
         "code_hashes": {
             "0.1.0": ""
         },
-        "wit_version": 0,
+        "wit_version": 1,
         "dependencies": []
     },
     "external_url": "",

--- a/src/new/templates/rust/no-ui/chat/pkg/manifest.json
+++ b/src/new/templates/rust/no-ui/chat/pkg/manifest.json
@@ -5,7 +5,7 @@
         "on_exit": "Restart",
         "request_networking": true,
         "request_capabilities": [
-            "http_server:distro:sys",
+            "http-server:distro:sys",
             "vfs:distro:sys"
         ],
         "grant_capabilities": [],

--- a/src/new/templates/rust/no-ui/chat/send/Cargo.toml
+++ b/src/new/templates/rust/no-ui/chat/send/Cargo.toml
@@ -6,10 +6,10 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
-kinode_process_lib = "0.9.6"
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/rust/no-ui/chat/test/chat-test/api/chat_test:template.os-v0.wit
+++ b/src/new/templates/rust/no-ui/chat/test/chat-test/api/chat_test:template.os-v0.wit
@@ -1,5 +1,5 @@
 world chat-test-template-dot-os-v0 {
     import chat;
     import tester;
-    include process-v0;
+    include process-v1;
 }

--- a/src/new/templates/rust/no-ui/chat/test/chat-test/chat-test/Cargo.toml
+++ b/src/new/templates/rust/no-ui/chat/test/chat-test/chat-test/Cargo.toml
@@ -7,13 +7,13 @@ publish = false
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3"
-kinode_process_lib = "0.9.2"
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8" }
 process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 rmp-serde = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/rust/no-ui/chat/test/chat-test/metadata.json
+++ b/src/new/templates/rust/no-ui/chat/test/chat-test/metadata.json
@@ -10,7 +10,7 @@
         "code_hashes": {
             "0.1.0": ""
         },
-        "wit_version": 0,
+        "wit_version": 1,
         "dependencies": [
             "chat:template.os",
             "tester:sys"

--- a/src/new/templates/rust/no-ui/echo/echo/Cargo.toml
+++ b/src/new/templates/rust/no-ui/echo/echo/Cargo.toml
@@ -6,11 +6,11 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
-kinode_process_lib = { version = "0.9.6", features = ["logging"] }
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8", features = ["logging"] }
 process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/rust/no-ui/echo/echo/src/lib.rs
+++ b/src/new/templates/rust/no-ui/echo/echo/src/lib.rs
@@ -3,7 +3,7 @@ use kinode_process_lib::{await_message, call_init, println, Address, Message, Re
 
 wit_bindgen::generate!({
     path: "target/wit",
-    world: "process-v0",
+    world: "process-v1",
 });
 
 fn handle_message(message: &Message) -> anyhow::Result<()> {

--- a/src/new/templates/rust/no-ui/echo/metadata.json
+++ b/src/new/templates/rust/no-ui/echo/metadata.json
@@ -10,7 +10,7 @@
         "code_hashes": {
             "0.1.0": ""
         },
-        "wit_version": 0,
+        "wit_version": 1,
         "dependencies": []
     },
     "external_url": "",

--- a/src/new/templates/rust/no-ui/echo/pkg/manifest.json
+++ b/src/new/templates/rust/no-ui/echo/pkg/manifest.json
@@ -5,7 +5,7 @@
         "on_exit": "Restart",
         "request_networking": true,
         "request_capabilities": [
-            "http_server:distro:sys",
+            "http-server:distro:sys",
             "vfs:distro:sys"
         ],
         "grant_capabilities": [],

--- a/src/new/templates/rust/no-ui/echo/test/echo-test/api/echo_test:template.os-v0.wit
+++ b/src/new/templates/rust/no-ui/echo/test/echo-test/api/echo_test:template.os-v0.wit
@@ -1,4 +1,4 @@
 world echo-test-template-dot-os-v0 {
     import tester;
-    include process-v0;
+    include process-v1;
 }

--- a/src/new/templates/rust/no-ui/echo/test/echo-test/echo-test/Cargo.toml
+++ b/src/new/templates/rust/no-ui/echo/test/echo-test/echo-test/Cargo.toml
@@ -7,13 +7,13 @@ publish = false
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3"
-kinode_process_lib = "0.9.2"
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8" }
 process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 rmp-serde = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/rust/no-ui/echo/test/echo-test/metadata.json
+++ b/src/new/templates/rust/no-ui/echo/test/echo-test/metadata.json
@@ -10,7 +10,7 @@
         "code_hashes": {
             "0.1.0": ""
         },
-        "wit_version": 0,
+        "wit_version": 1,
         "dependencies": [
             "tester:sys"
         ]

--- a/src/new/templates/rust/no-ui/fibonacci/api/fibonacci:template.os-v0.wit
+++ b/src/new/templates/rust/no-ui/fibonacci/api/fibonacci:template.os-v0.wit
@@ -12,5 +12,5 @@ interface fibonacci {
 
 world fibonacci-template-dot-os-v0 {
     import fibonacci;
-    include process-v0;
+    include process-v1;
 }

--- a/src/new/templates/rust/no-ui/fibonacci/fibonacci/Cargo.toml
+++ b/src/new/templates/rust/no-ui/fibonacci/fibonacci/Cargo.toml
@@ -6,11 +6,11 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
-kinode_process_lib = { version = "0.9.6", features = ["logging"] }
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8", features = ["logging"] }
 process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/rust/no-ui/fibonacci/metadata.json
+++ b/src/new/templates/rust/no-ui/fibonacci/metadata.json
@@ -10,7 +10,7 @@
         "code_hashes": {
             "0.1.0": ""
         },
-        "wit_version": 0,
+        "wit_version": 1,
         "dependencies": []
     },
     "external_url": "",

--- a/src/new/templates/rust/no-ui/fibonacci/number/Cargo.toml
+++ b/src/new/templates/rust/no-ui/fibonacci/number/Cargo.toml
@@ -6,10 +6,10 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
-kinode_process_lib = "0.9.6"
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/rust/no-ui/fibonacci/pkg/manifest.json
+++ b/src/new/templates/rust/no-ui/fibonacci/pkg/manifest.json
@@ -5,7 +5,7 @@
         "on_exit": "Restart",
         "request_networking": true,
         "request_capabilities": [
-            "http_server:distro:sys",
+            "http-server:distro:sys",
             "vfs:distro:sys"
         ],
         "grant_capabilities": [],

--- a/src/new/templates/rust/no-ui/fibonacci/test/fibonacci-test/api/fibonacci_test:template.os-v0.wit
+++ b/src/new/templates/rust/no-ui/fibonacci/test/fibonacci-test/api/fibonacci_test:template.os-v0.wit
@@ -1,5 +1,5 @@
 world fibonacci-test-template-dot-os-v0 {
     import fibonacci;
     import tester;
-    include process-v0;
+    include process-v1;
 }

--- a/src/new/templates/rust/no-ui/fibonacci/test/fibonacci-test/fibonacci-test/Cargo.toml
+++ b/src/new/templates/rust/no-ui/fibonacci/test/fibonacci-test/fibonacci-test/Cargo.toml
@@ -6,11 +6,11 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
-kinode_process_lib = "0.9.2"
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8" }
 process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/rust/no-ui/fibonacci/test/fibonacci-test/metadata.json
+++ b/src/new/templates/rust/no-ui/fibonacci/test/fibonacci-test/metadata.json
@@ -10,7 +10,7 @@
         "code_hashes": {
             "0.1.0": ""
         },
-        "wit_version": 0,
+        "wit_version": 1,
         "dependencies": [
             "fibonacci:template.os",
             "tester:sys"

--- a/src/new/templates/rust/no-ui/file-transfer/api/file-transfer:template.os-v0.wit
+++ b/src/new/templates/rust/no-ui/file-transfer/api/file-transfer:template.os-v0.wit
@@ -75,5 +75,5 @@ world file-transfer-worker-api-v0 {
 world file-transfer-template-dot-os-v0 {
     import file-transfer;
     import file-transfer-worker;
-    include process-v0;
+    include process-v1;
 }

--- a/src/new/templates/rust/no-ui/file-transfer/download/Cargo.toml
+++ b/src/new/templates/rust/no-ui/file-transfer/download/Cargo.toml
@@ -6,11 +6,11 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
-kinode_process_lib = "0.9.6"
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8" }
 process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/rust/no-ui/file-transfer/file-transfer-worker-api/Cargo.toml
+++ b/src/new/templates/rust/no-ui/file-transfer/file-transfer-worker-api/Cargo.toml
@@ -6,11 +6,11 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
-kinode_process_lib = "0.9.6"
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8" }
 process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/rust/no-ui/file-transfer/file-transfer-worker/Cargo.toml
+++ b/src/new/templates/rust/no-ui/file-transfer/file-transfer-worker/Cargo.toml
@@ -6,11 +6,11 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
-kinode_process_lib = { version = "0.9.6", features = ["logging"] }
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8", features = ["logging"] }
 process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/rust/no-ui/file-transfer/file-transfer/Cargo.toml
+++ b/src/new/templates/rust/no-ui/file-transfer/file-transfer/Cargo.toml
@@ -6,11 +6,11 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
-kinode_process_lib = { version = "0.9.6", features = ["logging"] }
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8", features = ["logging"] }
 process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/rust/no-ui/file-transfer/list-files/Cargo.toml
+++ b/src/new/templates/rust/no-ui/file-transfer/list-files/Cargo.toml
@@ -6,11 +6,11 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
-kinode_process_lib = "0.9.6"
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8" }
 process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/rust/no-ui/file-transfer/metadata.json
+++ b/src/new/templates/rust/no-ui/file-transfer/metadata.json
@@ -10,7 +10,7 @@
         "code_hashes": {
             "0.1.0": ""
         },
-        "wit_version": 0,
+        "wit_version": 1,
         "dependencies": [
             "file-transfer:template.os"
         ]

--- a/src/new/templates/rust/no-ui/file-transfer/pkg/manifest.json
+++ b/src/new/templates/rust/no-ui/file-transfer/pkg/manifest.json
@@ -5,7 +5,7 @@
         "on_exit": "Restart",
         "request_networking": true,
         "request_capabilities": [
-            "http_server:distro:sys",
+            "http-server:distro:sys",
             "vfs:distro:sys"
         ],
         "grant_capabilities": [],

--- a/src/new/templates/rust/no-ui/file-transfer/test/file-transfer-test/api/file-transfer-test:template.os-v0.wit
+++ b/src/new/templates/rust/no-ui/file-transfer/test/file-transfer-test/api/file-transfer-test:template.os-v0.wit
@@ -1,5 +1,5 @@
 world file-transfer-test-template-dot-os-v0 {
     import file-transfer;
     import tester;
-    include process-v0;
+    include process-v1;
 }

--- a/src/new/templates/rust/no-ui/file-transfer/test/file-transfer-test/file-transfer-test/Cargo.toml
+++ b/src/new/templates/rust/no-ui/file-transfer/test/file-transfer-test/file-transfer-test/Cargo.toml
@@ -7,13 +7,13 @@ publish = false
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3"
-kinode_process_lib = "0.9.2"
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8" }
 process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 rmp-serde = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/rust/no-ui/file-transfer/test/file-transfer-test/metadata.json
+++ b/src/new/templates/rust/no-ui/file-transfer/test/file-transfer-test/metadata.json
@@ -10,7 +10,7 @@
         "code_hashes": {
             "0.1.0": ""
         },
-        "wit_version": 0,
+        "wit_version": 1,
         "dependencies": [
             "file-transfer:template.os",
             "tester:sys"

--- a/src/new/templates/rust/ui/chat/chat/Cargo.toml
+++ b/src/new/templates/rust/ui/chat/chat/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3.3"
-kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.8.0" }
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "2a526c8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-wit-bindgen = "0.24.0"
+wit-bindgen = "0.36.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/new/templates/rust/ui/chat/chat/src/lib.rs
+++ b/src/new/templates/rust/ui/chat/chat/src/lib.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 
 wit_bindgen::generate!({
     path: "target/wit",
-    world: "process-v0",
+    world: "process-v1",
 });
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -204,11 +204,7 @@ fn handle_chat_request(
             };
 
             // Send a WebSocket message to the http server in order to update the UI
-            send_ws_push(
-                channel_id.clone(),
-                WsMessageType::Text,
-                blob,
-            );
+            send_ws_push(channel_id.clone(), WsMessageType::Text, blob);
         }
         ChatRequest::History => {
             // If this is an HTTP request, send a response to the http server

--- a/src/new/templates/rust/ui/chat/metadata.json
+++ b/src/new/templates/rust/ui/chat/metadata.json
@@ -10,7 +10,7 @@
         "code_hashes": {
             "0.1.0": ""
         },
-        "wit_version": 0,
+        "wit_version": 1,
         "dependencies": []
     },
     "external_url": "",

--- a/src/new/templates/rust/ui/chat/pkg/manifest.json
+++ b/src/new/templates/rust/ui/chat/pkg/manifest.json
@@ -5,7 +5,7 @@
         "on_exit": "Restart",
         "request_networking": true,
         "request_capabilities": [
-            "http_server:distro:sys",
+            "http-server:distro:sys",
             "vfs:distro:sys"
         ],
         "grant_capabilities": [],


### PR DESCRIPTION
## Problem

wit-bindgen is 12 versions behind and we aren't using wit process-v1 in our templates yet.

## Solution

Update

## Docs Update

None

## Notes

None