### PR TITLE
publish: fix metadata comparison & add mock

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -396,6 +396,7 @@ async fn execute(
             let max_fee_per_gas = matches
                 .get_one::<u128>("MAX_FEE_PER_GAS")
                 .and_then(|mfpg| Some(mfpg.clone()));
+            let mock = matches.get_one::<bool>("MOCK").unwrap();
 
             publish::execute(
                 &package_dir,
@@ -409,6 +410,7 @@ async fn execute(
                 *gas_limit,
                 max_priority_fee,
                 max_fee_per_gas,
+                mock,
             )
             .await
         }
@@ -1144,6 +1146,13 @@ async fn make_app(current_dir: &std::ffi::OsString) -> Result<Command> {
                 .long("fee-per-gas")
                 .help("The ETH transaction max fee per gas [default: estimated from network conditions]")
                 .value_parser(clap::builder::ValueParser::new(parse_u128_with_underscores))
+                .required(false)
+            )
+            .arg(Arg::new("MOCK")
+                .action(ArgAction::SetTrue)
+                .short('m')
+                .long("mock")
+                .help("If set, don't actually publish: just dry-run")
                 .required(false)
             )
         )

--- a/src/publish/mod.rs
+++ b/src/publish/mod.rs
@@ -162,11 +162,11 @@ async fn check_remote_metadata(
 
     // TODO: add derive(PartialEq) to Erc721
     let local_metadata_string = serde_json::to_string(&metadata).unwrap_or_default();
-    let local_metadata_value: serde_json::Value = serde_json::from_str(&local_metadata_string)
-        .unwrap_or_default();
+    let local_metadata_value: serde_json::Value =
+        serde_json::from_str(&local_metadata_string).unwrap_or_default();
     let remote_metadata_string = serde_json::to_string(&remote_metadata).unwrap_or_default();
-    let remote_metadata_value: serde_json::Value = serde_json::from_str(&remote_metadata_string)
-        .unwrap_or_default();
+    let remote_metadata_value: serde_json::Value =
+        serde_json::from_str(&remote_metadata_string).unwrap_or_default();
     if local_metadata_value != remote_metadata_value {
         return Err(eyre!(
             "{} and {} metadata do not match",
@@ -429,10 +429,7 @@ pub async fn execute(
     } else {
         let tx = provider.send_raw_transaction(&tx_encoded).await?;
         let tx_hash = format!("{:?}", tx.tx_hash());
-        let link = make_remote_link(
-            &format!("https://basescan.org/tx/{tx_hash}"),
-            &tx_hash,
-        );
+        let link = make_remote_link(&format!("https://basescan.org/tx/{tx_hash}"), &tx_hash);
         info!(
             "{} {name} tx sent: {link}",
             if *unpublish { "unpublish" } else { "publish" }

--- a/src/publish/mod.rs
+++ b/src/publish/mod.rs
@@ -161,7 +161,13 @@ async fn check_remote_metadata(
     let remote_metadata = read_and_update_metadata(&remote_metadata_dir)?;
 
     // TODO: add derive(PartialEq) to Erc721
-    if serde_json::to_string(&metadata)? != serde_json::to_string(&remote_metadata)? {
+    let local_metadata_string = serde_json::to_string(&metadata).unwrap_or_default();
+    let local_metadata_value: serde_json::Value = serde_json::from_str(&local_metadata_string)
+        .unwrap_or_default();
+    let remote_metadata_string = serde_json::to_string(&remote_metadata).unwrap_or_default();
+    let remote_metadata_value: serde_json::Value = serde_json::from_str(&remote_metadata_string)
+        .unwrap_or_default();
+    if local_metadata_value != remote_metadata_value {
         return Err(eyre!(
             "{} and {} metadata do not match",
             make_local_file_link_path(&package_dir.join("metadata.json"), "Local")
@@ -315,6 +321,7 @@ pub async fn execute(
     gas_limit: u64,
     max_priority_fee_per_gas: Option<u128>,
     max_fee_per_gas: Option<u128>,
+    mock: &bool,
 ) -> Result<()> {
     if !package_dir.join("pkg").exists() {
         return Err(eyre!(
@@ -414,15 +421,22 @@ pub async fn execute(
 
     let tx_envelope = tx.build(&wallet).await?;
     let tx_encoded = tx_envelope.encoded_2718();
-    let tx = provider.send_raw_transaction(&tx_encoded).await?;
-    let tx_hash = format!("{:?}", tx.tx_hash());
-    let link = make_remote_link(
-        &format!("https://basescan.org/tx/{tx_hash}"),
-        &tx_hash,
-    );
-    info!(
-        "{} {name} tx sent: {link}",
-        if *unpublish { "unpublish" } else { "publish" }
-    );
+    if *mock {
+        info!(
+            "{} {name} tx mock successful",
+            if *unpublish { "unpublish" } else { "publish" }
+        );
+    } else {
+        let tx = provider.send_raw_transaction(&tx_encoded).await?;
+        let tx_hash = format!("{:?}", tx.tx_hash());
+        let link = make_remote_link(
+            &format!("https://basescan.org/tx/{tx_hash}"),
+            &tx_hash,
+        );
+        info!(
+            "{} {name} tx sent: {link}",
+            if *unpublish { "unpublish" } else { "publish" }
+        );
+    }
     Ok(())
 }


### PR DESCRIPTION
## Problem

Logic for comparing metadata was not correct: depended on order of fields in JSON string.

## Solution

Compare `serde_json::Value`s instead, as we do in [Kinode core for capabilities](https://github.com/kinode-dao/kinode/blob/main/lib/src/core.rs#L486-L494).

## Docs Update

TODO: Add `mock` flag.

## Testing

https://gist.github.com/nick1udwig/28c66b376c8e425745fd70cedcc0efef

## Notes

None