### PR TITLE
reenable js: its not quite working yet

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -47,6 +47,7 @@ const KINODE_WIT_1_0_0_URL: &str =
 const WASI_VERSION: &str = "27.0.0"; // TODO: un-hardcode
 const DEFAULT_WORLD_0_7_0: &str = "process";
 const DEFAULT_WORLD_0_8_0: &str = "process-v0";
+const DEFAULT_WORLD_1_0_0: &str = "process-v1";
 const KINODE_PROCESS_LIB_CRATE_NAME: &str = "kinode_process_lib";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1564,7 +1565,8 @@ async fn compile_package(
     let wit_world = default_world
         .unwrap_or_else(|| match metadata.properties.wit_version {
             None => DEFAULT_WORLD_0_7_0,
-            Some(0) | _ => DEFAULT_WORLD_0_8_0,
+            Some(0) => DEFAULT_WORLD_0_8_0,
+            Some(1) | _ => DEFAULT_WORLD_1_0_0,
         })
         .to_string();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1049,8 +1049,8 @@ async fn make_app(current_dir: &std::ffi::OsString) -> Result<Command> {
                 .short('l')
                 .long("language")
                 .help("Programming language of the template")
-                .value_parser(["rust"])
-                //.value_parser(["rust", "python", "javascript"]) // TODO: resupport
+                .value_parser(["rust", "javascript"])
+                //.value_parser(["rust", "python", "javascript"])
                 .default_value("rust")
             )
             .arg(Arg::new("TEMPLATE")

--- a/src/new/componentize.mjs
+++ b/src/new/componentize.mjs
@@ -14,7 +14,7 @@ const witPath = 'target/wit';
 
 const { component } = await componentize(
     jsSource,
-    { witPath: witPath, worldName: worldName, debug: false },
+    { witPath: witPath, worldName: worldName, debug: false, disableFeatures: ['http'] },
 );
 
 await writeFile(`../pkg/${processName}.wasm`, component);

--- a/src/new/templates/javascript/no-ui/chat/chat/package.json
+++ b/src/new/templates/javascript/no-ui/chat/chat/package.json
@@ -9,6 +9,6 @@
   "author": "template.os",
   "license": "MIT",
   "dependencies": {
-    "@bytecodealliance/componentize-js": "0.5.0"
+    "@bytecodealliance/componentize-js": "0.15.1"
   }
 }

--- a/src/new/templates/javascript/no-ui/chat/chat/src/lib.js
+++ b/src/new/templates/javascript/no-ui/chat/chat/src/lib.js
@@ -1,4 +1,4 @@
-import { printToTerminal, receive, sendAndAwaitResponse, sendResponse } from "kinode:process/standard@0.7.0";
+import { printToTerminal, receive, sendAndAwaitResponse, sendResponse } from "kinode:process/standard@1.0.0";
 
 function parseAddress(addressString) {
     const [node, rest] = addressString.split('@');
@@ -36,48 +36,62 @@ function addToArchive(conversation, author, content, messageArchive) {
 }
 
 function handleMessage(ourNode, messageArchive) {
+    printToTerminal(0, `a`);
     const [source, message] = receive();
+    printToTerminal(0, `b`);
 
     if (message.tag == 'response') {
         throw new Error(`unexpected Response: ${JSON.stringify(message.val)}`);
     } else if (message.tag == 'request') {
+        printToTerminal(0, `c`);
         const { bytes: bodyBytes, string: body0 } = inputBytesToString(message.val.body)
+        printToTerminal(0, `d`);
         const body = JSON.parse(body0);
+        printToTerminal(0, `e`);
         const encoder = new TextEncoder();
         if (body.Send) {
+            printToTerminal(0, `f`);
             const { target, message: messageText } = body.Send;
+            printToTerminal(0, `g`);
             if (target === ourNode) {
+                printToTerminal(0, `h`);
                 printToTerminal(0, `chat|${source.node}: ${messageText}`);
+                printToTerminal(0, `i`);
                 messageArchive = addToArchive(
                     source.node,
                     source.node,
                     messageText,
                     messageArchive,
                 );
+                printToTerminal(0, `j`);
             } else {
+                printToTerminal(0, `k`);
                 sendAndAwaitResponse(
                     {
                         node: target,
                         process: {
                             processName: "chat",
                             packageName: "chat",
-                            publisherNode: "template.os"
+                            publisherNode: "template.os",
                         }
                     },
                     {
                         inherit: false,
                         expectsResponse: 5,
                         body: bodyBytes,
-                        metadata: null
+                        metadata: null,
+                        capabilities: [],
                     },
-                    null
+                    null,
                 );
+                printToTerminal(0, `l`);
                 messageArchive = addToArchive(
                     target,
                     ourNode,
                     messageText,
                     messageArchive,
                 );
+                printToTerminal(0, `m`);
             }
             sendResponse(
                 {
@@ -88,7 +102,9 @@ function handleMessage(ourNode, messageArchive) {
                 },
                 null
             );
+            printToTerminal(0, `n`);
         } else if (body.History) {
+            printToTerminal(0, `o`);
             sendResponse(
                 {
                     inherit: false,
@@ -98,6 +114,7 @@ function handleMessage(ourNode, messageArchive) {
                 },
                 null
             );
+            printToTerminal(0, `p`);
         } else {
             throw new Error(`Unexpected Request: ${body}`)
         }

--- a/src/new/templates/javascript/no-ui/echo/echo/package.json
+++ b/src/new/templates/javascript/no-ui/echo/echo/package.json
@@ -9,6 +9,6 @@
   "author": "template.os",
   "license": "MIT",
   "dependencies": {
-    "@bytecodealliance/componentize-js": "0.5.0"
+    "@bytecodealliance/componentize-js": "0.15.1"
   }
 }

--- a/src/new/templates/javascript/no-ui/echo/echo/src/lib.js
+++ b/src/new/templates/javascript/no-ui/echo/echo/src/lib.js
@@ -1,4 +1,4 @@
-import { printToTerminal, receive, sendResponse } from "kinode:process/standard@0.7.0";
+import { printToTerminal, receive, sendResponse } from "kinode:process/standard@1.0.0";
 
 function parseAddress(addressString) {
     const [node, rest] = addressString.split('@');

--- a/src/new/templates/javascript/no-ui/fibonacci/fibonacci/package.json
+++ b/src/new/templates/javascript/no-ui/fibonacci/fibonacci/package.json
@@ -9,6 +9,6 @@
   "author": "template.os",
   "license": "MIT",
   "dependencies": {
-    "@bytecodealliance/componentize-js": "0.5.0"
+    "@bytecodealliance/componentize-js": "0.15.1"
   }
 }

--- a/src/new/templates/javascript/no-ui/fibonacci/fibonacci/src/lib.js
+++ b/src/new/templates/javascript/no-ui/fibonacci/fibonacci/src/lib.js
@@ -1,6 +1,6 @@
 // 240103: Date.now() always returns 0, so this timing does not currently work.
 
-import { printToTerminal, receive, sendResponse } from "kinode:process/standard@0.7.0";
+import { printToTerminal, receive, sendResponse } from "kinode:process/standard@1.0.0";
 
 function parseAddress(addressString) {
     const [node, rest] = addressString.split('@');

--- a/src/new/templates/rust/no-ui/chat/pkg/scripts.json
+++ b/src/new/templates/rust/no-ui/chat/pkg/scripts.json
@@ -3,7 +3,9 @@
         "root": false,
         "public": false,
         "request_networking": false,
-        "request_capabilities": [],
+        "request_capabilities": [
+            "chat:chat:template.os"
+        ],
         "grant_capabilities": [
             "chat:chat:template.os"
         ],


### PR DESCRIPTION
## Problem

Want js

## Solution

Reenable js

## Docs Update

TODO

## Notes

* Not working entirely as of 4215210
* You can create fib & it works
* Chat does not work
* E.g.:

```
# Start a fakenode
kit f -r /path/to/1.0/fakenode/binary

# Fib works:
kit n fib -t fibonacci -l javascript
kit b fib
kit s fib

# In fake node
m our@fib:fib:template.os '{"Number": 5}'

# Chat doesn't work
# Here's how to see it:
kit n chat -l javascript
kit b chat
kit s chat

# In fake node
m our@fib:fib:template.os '{"Number": 5}'
```

Fib works, but chat gives the following:
```
m our@chat:chat:template.os '{"Send": {"target": "fake2.dev", "message": "hi"}}'
Fri 22:31 chat:template.os: b
Fri 22:31 chat:template.os: c
Fri 22:31 chat:template.os: d
Fri 22:31 chat:template.os: e
Fri 22:31 chat:template.os: f
Fri 22:31 chat:template.os: g
Fri 22:31 chat:template.os: k
Fri 22:31 chat:template.os: chat: got error TypeError: can't access property "length", vec20 is undefined
```