### PR TITLE
always use 1.85.1 toolchain

### DIFF
--- a/src/build_start_package/mod.rs
+++ b/src/build_start_package/mod.rs
@@ -26,6 +26,7 @@ pub async fn execute(
     reproducible: bool,
     force: bool,
     verbose: bool,
+    toolchain: &str,
 ) -> Result<()> {
     build::execute(
         package_dir,
@@ -46,6 +47,7 @@ pub async fn execute(
         force,
         verbose,
         false,
+        toolchain,
     )
     .await?;
     start_package::execute(package_dir, url).await?;

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -8,6 +8,7 @@ use reqwest::Client;
 use tokio::time::{sleep, Duration};
 use tracing::{debug, info, instrument};
 
+use crate::build;
 use crate::run_tests::cleanup::{clean_process_by_pid, cleanup_on_signal};
 use crate::run_tests::types::BroadcastRecvBool;
 use crate::setup::{check_foundry_deps, get_deps};
@@ -257,7 +258,14 @@ pub async fn start_chain(
     tracing: bool,
 ) -> Result<Option<Child>> {
     let deps = check_foundry_deps()?;
-    get_deps(deps, &mut recv_kill, false, verbose).await?;
+    get_deps(
+        deps,
+        &mut recv_kill,
+        false,
+        verbose,
+        build::DEFAULT_RUST_TOOLCHAIN,
+    )
+    .await?;
 
     info!("Checking for Anvil on port {}...", port);
     if wait_for_anvil(port, 1, None).await.is_ok() {

--- a/src/dev_ui/mod.rs
+++ b/src/dev_ui/mod.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use color_eyre::{eyre::eyre, Result};
 use tracing::{info, instrument};
 
-use crate::build::{make_fake_kill_chan, run_command};
+use crate::build::{make_fake_kill_chan, run_command, DEFAULT_RUST_TOOLCHAIN};
 use crate::setup::{check_js_deps, get_deps, get_newest_valid_node_version};
 
 #[instrument(level = "trace", skip_all)]
@@ -17,7 +17,7 @@ pub async fn execute(
     if !skip_deps_check {
         let deps = check_js_deps()?;
         let mut recv_kill = make_fake_kill_chan();
-        get_deps(deps, &mut recv_kill, false, false).await?;
+        get_deps(deps, &mut recv_kill, false, false, DEFAULT_RUST_TOOLCHAIN).await?;
     }
     let valid_node = get_newest_valid_node_version(None, None)?;
 

--- a/src/run_tests/mod.rs
+++ b/src/run_tests/mod.rs
@@ -13,7 +13,7 @@ use tracing::{debug, info, instrument};
 use hyperware_process_lib::kernel_types::PackageManifestEntry;
 
 use crate::boot_fake_node;
-use crate::build;
+use crate::build::{self, DEFAULT_RUST_TOOLCHAIN};
 use crate::chain;
 use crate::inject_message;
 use crate::start_package;
@@ -382,6 +382,7 @@ async fn build_packages(
             false,
             false,
             false,
+            DEFAULT_RUST_TOOLCHAIN,
         )
         .await?;
         debug!("Start {path:?}");
@@ -408,6 +409,7 @@ async fn build_packages(
             false,
             false,
             false,
+            DEFAULT_RUST_TOOLCHAIN,
         )
         .await?;
     }
@@ -431,6 +433,7 @@ async fn build_packages(
             false,
             false,
             false,
+            DEFAULT_RUST_TOOLCHAIN,
         )
         .await?;
     }


### PR DESCRIPTION
## Problem

Using `+stable` checks if we have stable; if we do we use that; if we don't we get latest stable.
This means that `+stable` is a different version on systems set up at different times.
Newer versions of cargo don't work, giving an LTO error.

## Solution

Specify `+1.85.1` -- a known working version -- by default.
Allow `--toolchain +foo` input to override.

## Docs Update

None

## Notes

https://discord.com/channels/1257731563374776341/1338934897322233898/1420786777895080037