### PR TITLE
convert usize and isize to u64 and s64

### DIFF
--- a/src/build/wit_generator.rs
+++ b/src/build/wit_generator.rs
@@ -225,6 +225,8 @@ fn rust_type_to_wit(ty: &Type, used_types: &mut HashSet<String>) -> Result<Strin
                 "u64" => Ok("u64".to_string()),
                 "f32" => Ok("f32".to_string()),
                 "f64" => Ok("f64".to_string()),
+                "usize" => Ok("u64".to_string()),
+                "isize" => Ok("s64".to_string()),
                 "String" => Ok("string".to_string()),
                 "bool" => Ok("bool".to_string()),
                 "Vec" => {


### PR DESCRIPTION
simple Rust usize/isize conversion to wit u64/s64.
not that it's unnecessary to do anything in caller_utils_ts_generator.rs because it will take the u64/s64 from wit and convert to ts "number".